### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ which creates a shared library and executable using the functions
 defined in the example system, assuming you have `libsbcl.so` and
 `libcalc.so` in a shared library path somewhere.
 
-NOTE: On Mac OS X you *MUST* specify `-pagezero-size 0x100000` when
+NOTE: On Mac OS X you *MUST* specify `-pagezero_size 0x100000` when
 linking the final executable, otherwise SBCL will fail to mmap its
 static space into the address `0x5000000`. This is because Mac decides
 to make page zero take up a whole `4GB` (!), which prevents access to


### PR DESCRIPTION
```
kssingh-m:example kssingh$ gcc -pagezero-size 0x100000 example.c -o example -lsbcl -lcalc -L.
clang: error: unknown argument '-pagezero-size'; did you mean '-pagezero_size'?
clang: error: no such file or directory: '0x100000'
```