### PR TITLE
Fix Python binding when exporting (ALIEN-NAME LISP-NAME)

### DIFF
--- a/python-bindings.lisp
+++ b/python-bindings.lisp
@@ -53,8 +53,7 @@
                                       :function-prefix (api-function-prefix api)
                                       :error-map (api-error-map api)
                                       :library-name library-name))
-                         :collect (let ((prefixed-name (prefix-name (api-function-prefix api) name)))
-                                    (if (listp prefixed-name) (car prefixed-name) prefixed-name)))))))
+                         :collect (coerce-to-c-name (prefix-name (api-function-prefix api) name)))))))
 
 (defun build-python-bindings (library directory)
   (let ((file-name (concatenate 'string (library-c-name library) ".py")))    

--- a/python-bindings.lisp
+++ b/python-bindings.lisp
@@ -53,7 +53,8 @@
                                       :function-prefix (api-function-prefix api)
                                       :error-map (api-error-map api)
                                       :library-name library-name))
-                         :collect (prefix-name (api-function-prefix api) name))))))
+                         :collect (let ((prefixed-name (prefix-name (api-function-prefix api) name)))
+                                    (if (listp prefixed-name) (car prefixed-name) prefixed-name)))))))
 
 (defun build-python-bindings (library directory)
   (let ((file-name (concatenate 'string (library-c-name library) ".py")))    


### PR DESCRIPTION
# Example library
```lisp
  (:function
   (("parse_quil" safely-parse-quil) quil-program ((source :string)))
   (("print_program" print-program) :void ((program quil-program)))
   (("compile_quil" compiler-hook) quil-program ((program quil-program) (chip-spec chip-specification)))
   (("compile_protoquil" compile-protoquil) quil-program ((program quil-program) (chip-spec chip-specification)))
   (("build_nq_linear_chip" cl-quil::build-nq-linear-chip) chip-specification ((n :int)))
   (("chip_spec_from_isa_descriptor" lookup-isa-descriptor-for-name) chip-specification ((descriptor :string)))
   (("print_chip_spec" print-chip-spec) :void ((chip-spec chip-specification)))))
```

# Before fix
```python
__all__ = ['quil_program', 'chip_specification', 'error_t', '(quilc_parse_quil
                                                              QUILC-SAFELY-PARSE-QUIL)', '(quilc_print_program
                                                                                           QUILC-PRINT-PROGRAM)', '(quilc_compile_quil
                                                                                                                    QUILC-COMPILER-HOOK)', '(quilc_compile_protoquil
                                                                                                                                             QUILC-COMPILE-PROTOQUIL)', '(quilc_build_nq_linear_chip
                                                                                                                                                                          QUILC-BUILD-NQ-LINEAR-CHIP)', '(quilc_chip_spec_from_isa_descriptor
                                                                                                                                                                                                          QUILC-LOOKUP-ISA-DESCRIPTOR-FOR-NAME)', '(quilc_print_chip_spec
                                                                                                                                                                                                                                                    QUILC-PRINT-CHIP-SPEC)', 'QUILC-RELEASE-HANDLE', 'QUILC-HANDLE-EQ']
```

# After fix
```python
__all__ = ['quil_program', 'chip_specification', 'error_t', 'quilc_parse_quil', 'quilc_print_program', 'quilc_compile_quil', 'quilc_compile_protoquil', 'quilc_build_nq_linear_chip', 'quilc_chip_spec_from_isa_descriptor', 'quilc_print_chip_spec', 'QUILC-RELEASE-HANDLE', 'QUILC-HANDLE-EQ']
```