### PR TITLE
allow for multiple cases in DEFINE-ERROR-MAP

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -15,7 +15,7 @@ Error maps control how Lisp errors get translated to error codes at exported fun
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (defmethod wrap-error-handling (form (error-map (eql ',name)))
        `(handler-case (progn ,form ,,no-error)
-          ,',@cases))
+          ,,@(loop :for case :in cases :collect (list 'quote case))))
      (defmethod error-map-type ((error-map (eql ',name)))
        ',error-type)
      (defmethod error-map-success-code ((error-map (eql ',name)))


### PR DESCRIPTION
This fixes a small issue with the `DEFINE-ERROR-MAP` macro, in which it would not correctly handle > 1 cases.

For example,
```
(sbcl-librarian:define-error-map test-map :int 0
  (warning (condition) 0)
  (t (condition) 1))
```
would not expand properly under the previous version.