### PR TITLE
use HANDLER-BIND for error handling at API boundary

### DIFF
--- a/example/bindings.lisp
+++ b/example/bindings.lisp
@@ -7,7 +7,9 @@
   ("ERR_SUCCESS" 0)
   ("ERR_FAIL" 1))
 (define-error-map error-map error-type 0
-  (t (condition) (declare (ignore condition)) 1))
+  ((t (lambda (condition)
+        (declare (ignore condition))
+        (return-from error-map 1)))))
 
 (define-api libcalc-api (:error-map error-map
                          :function-prefix "calc_")


### PR DESCRIPTION
This updates `define-error-map` to use `handler-bind` rather than `handler-case` for error handling at the API boundary. The macro now establishes a block with a label corresponding to the error map name, so that error codes can get returned.

I can think of at least two ways in which this is convenient
- if we want to handle warnings without otherwise interrupting behavior (e.g. for logging), we can handle them here and then `continue`
- if we want to dump a backtrace on a real failure, having access to the full stack is important