### PR TITLE
Make example build with a single make command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,25 @@ version >2.1.10.
 
 You can build the example library using the Makefile in the example
 directory, which produces a header file, a source file, and a core
-file, and then you can compile the artifacts like so with:
+file
 
-`gcc -c -fpic libcalc.c`
+You can compile example like so with:
 
-`gcc -shared libcalc.o -o libcalc.so -lsbcl`
+```
+export SBCL_SRC=~/.roswell/src/sbcl-2.2.4
 
-`gcc example.c -o example -lsbcl -lcalc -L.`
+cd example
+make
+
+./example
+```
 
 which creates a shared library and executable using the functions
-defined in the example system, assuming you have `libsbcl.so` and
-`libcalc.so` in a shared library path somewhere.
+defined in the example system, assuming you have `libsbcl.so`
+in a `${SBCL_SRC}/src/runtime/`.
 
-If you don't have `libsbcl.so`, you can build it by cloning the sbcl
-sources and running `make-shared-library.sh`. Then the artifact will
-be in `src/runtime/`.
+If you don't have `libsbcl.so`, make will try to build it for you
+by calling `make-shared-library.sh` at `${SBCL_SRC}` directory.
 
 NOTE: On Intel Mac OS X you *MUST* specify `-pagezero_size 0x100000`
 when linking the final executable, otherwise SBCL will fail to mmap

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,11 +1,23 @@
+EXAMPLES_DIR := $(shell pwd)
+ROOT_DIR := $(shell dirname $(EXAMPLES_DIR))
+
 .PHONY: all clean
 
-all: libcalc.dylib
+all: example
+
+example: libsbcl.so libcalc.dylib
+	$(CC) example.c -o example -lsbcl -lcalc -L.
+
+# For some reason, even on OSX SBCL builds its library with *.so
+# extension, but this works!
+libsbcl.so: $(SBCL_SRC)
+	test ! -e $(SBCL_SRC)/src/runtime/libsbcl.so && cd $(SBCL_SRC) && ./make-shared-library.sh
+	cp $(SBCL_SRC)/src/runtime/libsbcl.so ./
 
 libcalc.core libcalc.c libcalc.h libcalc.py: libcalc.lisp
-	$(SBCL_SRC)/run-sbcl.sh --script "script.lisp"
+	CL_SOURCE_REGISTRY="$(ROOT_DIR)//" $(SBCL_SRC)/run-sbcl.sh --script "script.lisp"
 
 libcalc.dylib: libcalc.core libcalc.c
 	$(CC) -dynamiclib -o $@ libcalc.c -L$(SBCL_SRC)/src/runtime -lsbcl
 clean:
-	rm -f libcalc.c libcalc.h libcalc.core libcalc.py libcalc.dylib
+	rm -f example libsbcl.so libcalc.c libcalc.h libcalc.core libcalc.py libcalc.dylib

--- a/example/Makefile
+++ b/example/Makefile
@@ -11,7 +11,7 @@ example: libsbcl.so libcalc.dylib
 # For some reason, even on OSX SBCL builds its library with *.so
 # extension, but this works!
 libsbcl.so: $(SBCL_SRC)
-	test ! -e $(SBCL_SRC)/src/runtime/libsbcl.so && cd $(SBCL_SRC) && ./make-shared-library.sh
+	test ! -e $(SBCL_SRC)/src/runtime/libsbcl.so && cd $(SBCL_SRC) && ./make-shared-library.sh || true
 	cp $(SBCL_SRC)/src/runtime/libsbcl.so ./
 
 libcalc.core libcalc.c libcalc.h libcalc.py: libcalc.lisp


### PR DESCRIPTION
This pull is similar to https://github.com/quil-lang/sbcl-librarian/pull/22 but only touches an example building process.

Main differences are:

* it builds libsbcl.so, automatically if it is missing;
* copies libsbcl.so instead of linking, making it easier to distribute it along with main executable;
* does not use Quicklisp and sets ASDF source registry using environment variable

Tested on OSX M1 with SBCL 2.2.2 and 2.2.4, installed using Roswell. But should work with a custom SBCL installation too.