### PR TITLE
Support core file compression.

### DIFF
--- a/example/script.lisp
+++ b/example/script.lisp
@@ -7,4 +7,4 @@
 
 (build-bindings libcalc ".")
 (build-python-bindings libcalc ".")
-(build-core-and-die libcalc ".")
+(build-core-and-die libcalc "." :compression t)

--- a/src/library.lisp
+++ b/src/library.lisp
@@ -63,9 +63,10 @@ NOTE: Here, the APIs must already be defined elsewhere."
                               (prefix-name (api-function-prefix api) (first spec)))
                             things))))
 
-(defun build-core-and-die (library directory)
+(defun build-core-and-die (library directory &key compression)
   (let* ((c-name (library-c-name library))
          (core-name (concatenate 'string c-name ".core")))
     (sb-ext:save-lisp-and-die
      (merge-pathnames core-name directory)
+     :compression compression
      :callable-exports (callable-exports library))))


### PR DESCRIPTION
Now `build-core-and-die` function has `compression` key argument. If it is `true`, then core file will be compressed. Example project uses this option and core file now 9.5M instead of 37M.