### PR TITLE
disallow multiple initializations

### DIFF
--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -59,8 +59,12 @@
           (c-function-declaration name ':int '((core :string))
                                   :datap nil
                                   :linkage linkage))
+  (format stream "  static int initialized = 0;~%")
   (format stream "  char *init_args[] = {\"\", \"--core\", core, \"--noinform\"};~%")
-  (format stream "  return initialize_lisp(4, init_args); }"))
+  (format stream "  if (initialized) return 1;~%")
+  (format stream "  if (initialize_lisp(4, init_args) != 0) return -1;~%")
+  (format stream "  initialized = 1;~%")
+  (format stream "  return 0; }"))
 
 (defun build-bindings (library directory)
   (let* ((c-name (library-c-name library))


### PR DESCRIPTION
It's an error to call `initialize_lisp` twice, so we might as well disallow it here.