### PR TITLE
Use correct name when initializing callable symbol

### DIFF
--- a/src/function.lisp
+++ b/src/function.lisp
@@ -80,4 +80,4 @@
                     (wrap-error-handling result error-map)
                     result))))
          (when *initialize-callables-p*
-           (sb-alien::initialize-alien-callable-symbol ',name))))))
+           (sb-alien::initialize-alien-callable-symbol ',callable-name))))))


### PR DESCRIPTION
## Notes
`name` doesn't include the prefix specified by `:function-prefix`, so `initialize-alien-callable-symbol` isn't finding the correct symbol to patch. Use `callable-name` instead. ~~and pass a two-element list containing a string of the function's C name and the function's Lisp name so that we hit [this case](https://github.com/sbcl/sbcl/blob/7026bb841aa63c4d43339afb49d837a4497c468a/src/code/target-alieneval.lisp#L49) in `pick-lisp-and-alien-names`, which is [called by `initialize-alien-callable-symbol`](https://github.com/sbcl/sbcl/blob/7026bb841aa63c4d43339afb49d837a4497c468a/src/code/alien-callback.lisp#L319).~~

## Testing
Verified correct behavior on macOS.