### PR TITLE
Add more support for FASL loading in Python bindings

### DIFF
--- a/src/function.lisp
+++ b/src/function.lisp
@@ -80,4 +80,4 @@
                     (wrap-error-handling result error-map)
                     result))))
          (when *initialize-callables-p*
-           (sb-alien::initialize-alien-callable-symbol ',name))))))
+           (sb-alien::initialize-alien-callable-symbol ',callable-name))))))

--- a/src/python-bindings.lisp
+++ b/src/python-bindings.lisp
@@ -56,12 +56,14 @@
                                       :library-name library-name))
                          :collect (coerce-to-c-name (prefix-name (api-function-prefix api) name)))))))
 
-(defun build-python-bindings (library directory &key (omit-init-call nil))
+(defun build-python-bindings (library directory &key (omit-init-call nil) (text-between-header-and-exports ""))
   (let ((file-name (concatenate 'string (library-c-name library) ".py")))    
     (with-open-file (stream (merge-pathnames file-name directory)
                             :direction :output
                             :if-exists :supersede)
       (funcall 'write-default-python-header library stream omit-init-call)
+      (write-string text-between-header-and-exports stream)
+      (terpri stream)
       (let* ((api-exports 
                (loop :for api :in (library-apis library)
                      :append (write-api-to-python api (library-c-name library) stream))))


### PR DESCRIPTION
## Notes
This PR does two things:

1. Add an option to omit the call to `init` when generating Python bindings, mirroring #33 
2. Add an option to insert user-specified text **after** the DLL load but **before** the function exports when generating Python bindings. The motivating use case for this is to allow users to call `lisp_load` immediately after the DLL is loaded, which has the effect of 1) loading new Lisp into the current core and then 2) initializing the alien callable symbols that were just added to the running process via the DLL load.

## Testing
Tested FASL loading through generated Python bindings on macOS
