### PR TITLE
Use locking around handle creation

### DIFF
--- a/sbcl-librarian.asd
+++ b/sbcl-librarian.asd
@@ -3,6 +3,7 @@
 (asdf:defsystem #:sbcl-librarian
   :description "Tool for generating Lisp bindings."
   :author "Charles Zhang <czhang@hrl.com>"
+  :depends-on (#:bordeaux-threads)
   ; :license "TODO"
   ; :version "0.0.1"
   :in-order-to ((test-op (test-op "sbcl-librarian/tests")))

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -100,7 +100,6 @@ Keyword Arguments
 (define-type :void
     :c-type "void" :alien-type sb-alien:void :python-type "None")
 
-
 ;;; some convenience type constructors
 
 (defmacro define-handle-type (name c-type)


### PR DESCRIPTION
I ran into some cases where parallel execution caused incorrect results. I believe the problem is that parallel calls to `make-handle` could associate multiple handles to a single key. Locking around `make-handle` resolves the issue.