### PR TITLE
FASL Libraries

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
         LD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime:/usr/local/lib
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
       run: |
-        $SBCL_SRC/run-sbcl.sh --script script.lisp
+        $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         gcc -Wall -fPIC -shared -o libcalc.so libcalc.c -lsbcl
         gcc -Wall -o example example.c -lcalc -lsbcl
         sudo mv libcalc.so /usr/local/lib

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -41,7 +41,7 @@ jobs:
         DYLD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime:.
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
       run: |
-        $SBCL_SRC/run-sbcl.sh --script script.lisp
+        $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         gcc -Wall -fPIC -shared -o libcalc.dylib libcalc.c -lsbcl
         gcc -Wall -o example example.c -lcalc -lsbcl
         echo "(+ 1 2)" | ./example | tr -d '\n' | grep "> 3> "

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
         MSYS2_PATH_TYPE: inherit
       run: |
-        $SBCL_SRC/run-sbcl.sh --script script.lisp
+        $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         ${{ matrix.cc }} -Wall -fPIC -shared -Wl,--export-all-symbols -o libcalc.dll libcalc.c -Wl,--whole-archive $SBCL_SRC/src/runtime/libsbcl.a -Wl,--no-whole-archive -ladvapi32 -lsynchronization -lws2_32 -lzstd
         ${{ matrix.cc }} -Wall -o example example.c -lcalc -L.
         mv libcalc.dll $MSYSTEM_PREFIX/bin

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 *.wx32fsl
 
 __pycache__
+
+*~
+\#*
+**/build

--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ Process resources SBCL uses:
   so the compiler can generate manifest literal addresses in machine
   code on some platforms, as well as to compute stable hashes of
   certain constants like NIL.
+

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -1,6 +1,6 @@
 (require '#:asdf)
 
-(asdf:load-system '#:libcalc)
+(ql:quickload '#:libcalc)
 
 (when (uiop:getenv "CI")
   (push :github-ci *features*))

--- a/sbcl-librarian.asd
+++ b/sbcl-librarian.asd
@@ -6,9 +6,13 @@
   ; :license "TODO"
   ; :version "0.0.1"
   :in-order-to ((test-op (test-op "sbcl-librarian/tests")))
+  :depends-on (#:sb-sprof
+               #:swank
+               )
   :serial t
   :pathname "src/"
   :components ((:file "package")
+               (:file "asdf-utils")
                (:file "types")
                (:file "function")
                (:file "api")
@@ -17,7 +21,8 @@
                (:file "python-bindings")
                (:file "handles")
                (:file "loader")
-               (:file "environment")))
+               (:file "environment")
+               (:file "fasl-lib")))
 
 (asdf:defsystem #:sbcl-librarian/project
   :description "Project skeleton builder for SBCL-LIBRARIAN"

--- a/src/asdf-utils.lisp
+++ b/src/asdf-utils.lisp
@@ -1,0 +1,90 @@
+(in-package #:sbcl-librarian)
+
+;; TODO: create a custom ASDF operation instead of monkey-patching
+;; PREPARE-BUNDLE-OP
+(defun call-with-recursive-compile-bundle-op (thunk)
+  "Call THUNK in a dynamic context where performing
+COMPILE-BUNDLE-OP on a target system recursively performs
+COMPILE-BUNDLE-OP on all the systems required by the target
+system. This is necessary because the the SIDEWAY-OPERATION of
+PREPARE-BUNDLE-OP, which is the SELFWARD-OPERATION of
+COMPILE-BUNDLE-OP, is LOAD-OP on SBCL instead of LOAD-BUNDLE-OP[^1].
+
+[^1]: https://github.com/sbcl/sbcl/blob/sbcl-2.4.0/contrib/asdf/asdf.lisp#L3972"
+  (let ((old-op (slot-value (asdf:make-operation 'asdf:prepare-bundle-op) 'asdf:sideway-operation)))
+    (setf (slot-value (asdf:make-operation 'asdf:prepare-bundle-op) 'asdf:sideway-operation) 'asdf:compile-bundle-op)
+    (unwind-protect
+         (values (funcall thunk))
+      (setf (slot-value (asdf:make-operation 'asdf:prepare-bundle-op) 'asdf:sideway-operation) old-op))))
+
+(defmacro with-recursive-compile-bundle-op (&body body)
+  "Syntactic sugar for CALL-WITH-RECURSIVE-COMPILE-BUNDLE-OP."
+  `(call-with-recursive-compile-bundle-op
+    (lambda ()
+      ,@body)))
+
+(defun call-with-output-translations (output-translations thunk)
+  "Call THUNK in a dynamic context where ASDF's output translations are
+initialized to OUTPUT-TRANSLATIONS."
+  (asdf:initialize-output-translations output-translations)
+  (unwind-protect
+       (funcall thunk)
+    (asdf:clear-output-translations)))
+
+(defmacro with-output-translations (output-translations &body body)
+  "Syntactic sugar for CALL-WITH-OUTPUT-TRANSLATIONS."
+  `(call-with-output-translations
+    ,output-translations
+    (lambda ()
+      ,@body)))
+
+(defun compile-bundle-system-with-dependencies (target-system directory)
+  "Compile TARGET-SYSTEM and all of its required systems into a single
+FASL bundle file per system, placing the FASL bundle files in
+DIRECTORY."
+  (with-output-translations
+      `(:output-translations
+        :inherit-configuration
+        ,@(loop :for system :in (cons target-system (system-dependencies-in-load-order target-system))
+                :for fasl-filename := (system-fasl-bundle-filename system)
+                :when (system-loadable-from-fasl-p system)
+                  :collect `((,(asdf:component-pathname system) ,fasl-filename)
+                             (,directory ,(directory-namestring fasl-filename)))))
+    (with-recursive-compile-bundle-op
+      (asdf:oos 'asdf:compile-bundle-op target-system))))
+
+(defun system-dependencies-in-load-order (system)
+  "Return a list of all the required systems for SYSTEM topologically
+sorted by load order."
+  (with-recursive-compile-bundle-op
+    ;; ASDF:REQUIRED-COMPONENTS traverses the dependency operations
+    ;; required to perform :GOAL-OPERATION on the provided system,
+    ;; returning a list of the components involved that have
+    ;; :COMPONENT-TYPE.
+    ;;
+    ;; TODO: what exactly do :OTHER-SYSTEMS and :KEEP-OPERATION do?
+    (asdf:required-components system
+                              :other-systems t
+                              :component-type 'asdf:system
+                              :goal-operation 'asdf:compile-bundle-op
+                              :keep-operation 'asdf:compile-bundle-op)))
+
+(defun system-fasl-bundle-filename (system)
+  "Returns the name of the FASL bundle file produced by performing
+COMPILE-BUNDLE-OP on SYSTEM."
+  (let ((files (asdf:output-files 'asdf:compile-bundle-op system)))
+    (if (null files)
+        nil
+        (uiop:parse-native-namestring
+         (concatenate 'string (asdf:component-name system) "--system.fasl")))))
+
+(defun require-system-p (system)
+  "Returns T if SYSTEM is a REQUIRE-SYSTEM, otherwise returns NIL."
+  (typep system 'asdf:require-system))
+
+(defun system-loadable-from-fasl-p (system)
+  "Returns T if SYSTEM is not a REQUIRE-SYSTEM and performing
+COMPILE-BUNDLE-OP on it produces an output file, otherwise returns
+NIL."
+  (not (or (require-system-p system)
+           (null (asdf:output-files 'asdf:compile-bundle-op system)))))

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -142,7 +142,7 @@
       ;;
       ;; [^1]: https://github.com/llvm/llvm-project/blob/ceade83ad5fc529f2b2beb896eec0dd0b29fdd44/llvm/docs/ExceptionHandling.rst#id32
       ;; [^2]: https://github.com/llvm/llvm-project/blob/ceade83ad5fc529f2b2beb896eec0dd0b29fdd44/clang/include/clang/Basic/Builtins.td#L897
-      (format stream "#ifdef __clang__~%# define JMP_BUF_CAST (void **)~%#else~%# define JMP_BUF_CAST~%#endif~%~%")
+      (format stream "#if defined(__clang__) && defined(_WIN32)~%# define JMP_BUF_CAST (void **)~%#else~%# define JMP_BUF_CAST~%#endif~%~%")
       (when (sb-sys:find-foreign-symbol-address "set_lossage_handler")
         (format stream "void set_lossage_handler(void (*handler)(void));~%"))
       (format stream "void ldb_monitor(void);~%~%")

--- a/src/fasl-lib.lisp
+++ b/src/fasl-lib.lisp
@@ -1,0 +1,145 @@
+(in-package #:sbcl-librarian)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defparameter *incbin-filename* "incbin.h"
+    "The name of the file containing the incbin source code.")
+  (defparameter *incbin-source-text*
+    (uiop:read-file-string
+     (asdf:system-relative-pathname "sbcl-librarian"
+                                    (uiop:merge-pathnames* *incbin-filename* "src/")))
+    "The full source code of incbin."))
+
+(defparameter *fasl-loader-filename* "fasl_loader.c"
+  "The name of the C source file that contains both embedded FASLs and a
+shared library constructor that loads the embedded FASLs.")
+(defparameter *fasl-loader-constructor-name* "load_embedded_fasls"
+  "The name of the shared library constructor that loads embedded FASLs.")
+
+(defparameter *cmake-minimum-required* "3.12"
+  "The minimum version of CMake required to run the generated project.")
+
+(defparameter *base-library-name* "sbcl"
+  "The name of the shared library (minus the file suffix and 'lib' prefix) containing the
+SBCL runtime.")
+
+(defun create-fasl-library-cmake-project (system-name library directory &key (base-library-name "sbcl"))
+  "Generate a CMake project in DIRECTORY for a shared library that, when
+loaded into a process that has already initialized the SBCL runtime,
+adds the C symbols for LIBRARY to the current process's symbol table
+and loads SYSTEM-NAME and its dependencies into the Lisp image while
+also initializing the new C symbols.
+
+The shared library depends on BASE-LIBRARY-NAME and contains C symbols
+for the API of LIBRARY, an embedded FASL bundle file per every ASDF
+system required by SYSTEM-NAME (including itself), and a shared
+library constructor function that loads the embedded FASL bundle files
+into the current image, using functions exported by BASE-LIBRARY-NAME,
+skipping those for already-loaded systems."
+  (let* ((target-system (asdf:find-system system-name))
+         (build-directory (uiop:ensure-pathname (uiop:native-namestring directory)
+                                                :namestring :native
+                                                :defaults *default-pathname-defaults*
+                                                :ensure-absolute t
+                                                :ensure-directory t
+                                                :ensure-directories-exist t))
+         (systems (append (system-dependencies-in-load-order target-system)
+                          (list target-system)))
+         (*base-library-name* base-library-name))
+    (compile-bundle-system-with-dependencies target-system build-directory)
+    (build-bindings library build-directory :omit-init-function t :fasl-lib-p t)
+    (create-incbin-source-file build-directory)
+    (create-fasl-loader-source-file library systems build-directory)
+    (create-cmakelists-file library systems build-directory)))
+
+(defun create-incbin-source-file (directory)
+  "Copy the incbin source code to DIRECTORY."
+  (with-open-file (stream (uiop:merge-pathnames* *incbin-filename* directory) :direction :output)
+    (format stream *incbin-source-text*)))
+
+(defun system-c-name (system)
+  "Replaces #\-, #\/, and #\. with #\_ in SYSTEM's name so as to produce
+a valid C identifier."
+  (loop :with name := (asdf:component-name system)
+        :for c :across "-/."
+        :do (setf name (substitute #\_ c name))
+        :finally (return name)))
+
+(defun fasl-library-load-function-name (library)
+  "Returns the name of the C function for loading the embedded FASLs for LIBRARY."
+  (concatenate 'string (library-c-name library) "_load"))
+
+(defun create-fasl-loader-source-file (library systems directory)
+  "Create a C source file in the DIRECTORY that embeds each of the FASL
+bundle files for non-required SYSTEMS using incbin and exports a
+function that requires any required SYSTEMs and then loads the
+embedded FASL bundles while also initializing any alien callable
+symbols defined in SYSTEMS. The C functions to perform
+-requiring and loading are included from *BASE-LIBRARY-NAME*.h."
+  (flet ((write-load-calls (stream indent-size)
+           (loop :for system :in (remove-if-not #'system-loadable-from-fasl-p systems)
+                 :for system-name := (asdf:component-name system)
+                 :for c-name := (system-c-name system)
+                 :for data-name := (concatenate 'string c-name "_fasl_data")
+                 :for size-name := (concatenate 'string c-name "_fasl_size")
+                 :do (format stream "~v@{ ~}lisp_load_array_as_system((void *) ~A, ~A, \"~A\");~%"
+                             indent-size data-name size-name system-name)))
+         (write-require-calls (stream indent-size)
+           (loop :for system :in (remove-if-not #'require-system-p systems)
+                 :for system-name := (asdf:component-name system)
+                 :when (typep system 'asdf:require-system)
+                   :do (format stream "~v@{ ~}lisp_require(\"~A\");~%" indent-size system-name))))
+    (with-open-file (stream (uiop:merge-pathnames* *fasl-loader-filename* directory) :direction :output)
+      #+win32
+      (format stream "#include <Windows.h>~%")
+      (format stream "#include \<lib~A.h\>~%" *base-library-name*)
+      (terpri stream)
+      (format stream "#define INCBIN_STYLE INCBIN_STYLE_SNAKE~%")
+      (format stream "#define INCBIN_PREFIX~%")
+      (format stream "#include \"incbin.h\"~%")
+      (terpri stream)
+      (loop :for system :in (remove-if-not #'system-loadable-from-fasl-p systems)
+            :for c-name := (system-c-name system)
+            :for fasl-filename := (system-fasl-bundle-filename system)
+            :do (format stream "INCBIN(~A_fasl, \"~A\");~%" c-name fasl-filename))
+      (terpri stream)
+      (progn
+        (let ((function-name (fasl-library-load-function-name library)))
+          (format stream "__attribute__((constructor))~%static void ~A(void) {~%" function-name)
+          #+win32
+          (let ((buf-size 1024))
+            (format stream "    char dll_path[~D];~%" buf-size)
+            (format stream "    HMODULE dll_mod;~%")
+            (format stream "    GetModuleHandleEx(~%")
+            (format stream "        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,~%")
+            (format stream "        ~A,~%" function-name)
+            (format stream "        &dll_mod);~%")
+            (format stream "    GetModuleFileNameA(dll_mod, dll_path, ~D);~%" buf-size)
+            (format stream "    lisp_load_shared_object(dll_path);~%")))
+        (write-require-calls stream 4)
+        (write-load-calls stream 4)
+        (format stream "}")))))
+
+(defun create-cmakelists-file (library systems directory)
+  "Create the CMakeLists.txt file for the project in DIRECTORY. This file
+contains directives for copying the FASL bundle files into the build
+directory, building the shared library, and installing the shared
+library and its header file."
+  (let* ((c-name (library-c-name library))
+         (bindings-filename (concatenate 'string c-name ".c"))
+         (loadable-systems (remove-if-not #'system-loadable-from-fasl-p systems))
+         (source-filenames (append (list bindings-filename *incbin-filename* *fasl-loader-filename*)
+                                   (mapcar #'system-fasl-bundle-filename loadable-systems))))
+    (with-open-file (stream (uiop:merge-pathnames* "CMakeLists.txt" directory) :direction :output)
+      (format stream "cmake_minimum_required(VERSION ~A)~%" *cmake-minimum-required*)
+      (format stream "project(~A)~%" c-name)
+      (loop :for system :in loadable-systems
+            :for fasl-filename := (system-fasl-bundle-filename system)
+            :do (format stream "configure_file(${CMAKE_CURRENT_SOURCE_DIR}/~A ${CMAKE_CURRENT_BINARY_DIR}/~A COPYONLY)~%"
+                        fasl-filename fasl-filename))
+      #+win32
+      (format stream "set(CMAKE_FIND_LIBRARY_SUFFIXES .dll ${CMAKE_FIND_LIBRARY_SUFFIXES})~%")
+      (format stream "find_library(BASE_LIBRARY NAMES lib~A${CMAKE_SHARED_LIBRARY_SUFFIX})~%" *base-library-name*)
+      (format stream "add_library(~A SHARED ~{~A~^ ~}~@{ ~A~})~%" c-name source-filenames #+win32 "${BASE_LIBRARY}")
+      (format stream "target_link_libraries(~A PRIVATE ${BASE_LIBRARY})~%" c-name)
+      (format stream "install(TARGETS ~A LIBRARY RUNTIME)~%" c-name)
+      (format stream "install(FILES ~A.h TYPE INCLUDE)~%" c-name))))

--- a/src/incbin.h
+++ b/src/incbin.h
@@ -1,0 +1,476 @@
+/**
+ * @file incbin.h
+ * @author Dale Weiler
+ * @brief Utility for including binary files
+ *
+ * Facilities for including binary files into the current translation unit and
+ * making use from them externally in other translation units.
+ */
+#ifndef INCBIN_HDR
+#define INCBIN_HDR
+#include <limits.h>
+#if   defined(__AVX512BW__) || \
+      defined(__AVX512CD__) || \
+      defined(__AVX512DQ__) || \
+      defined(__AVX512ER__) || \
+      defined(__AVX512PF__) || \
+      defined(__AVX512VL__) || \
+      defined(__AVX512F__)
+# define INCBIN_ALIGNMENT_INDEX 6
+#elif defined(__AVX__)      || \
+      defined(__AVX2__)
+# define INCBIN_ALIGNMENT_INDEX 5
+#elif defined(__SSE__)      || \
+      defined(__SSE2__)     || \
+      defined(__SSE3__)     || \
+      defined(__SSSE3__)    || \
+      defined(__SSE4_1__)   || \
+      defined(__SSE4_2__)   || \
+      defined(__neon__)     || \
+      defined(__ARM_NEON)   || \
+      defined(__ALTIVEC__)
+# define INCBIN_ALIGNMENT_INDEX 4
+#elif ULONG_MAX != 0xffffffffu
+# define INCBIN_ALIGNMENT_INDEX 3
+# else
+# define INCBIN_ALIGNMENT_INDEX 2
+#endif
+
+/* Lookup table of (1 << n) where `n' is `INCBIN_ALIGNMENT_INDEX' */
+#define INCBIN_ALIGN_SHIFT_0 1
+#define INCBIN_ALIGN_SHIFT_1 2
+#define INCBIN_ALIGN_SHIFT_2 4
+#define INCBIN_ALIGN_SHIFT_3 8
+#define INCBIN_ALIGN_SHIFT_4 16
+#define INCBIN_ALIGN_SHIFT_5 32
+#define INCBIN_ALIGN_SHIFT_6 64
+
+/* Actual alignment value */
+#define INCBIN_ALIGNMENT \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _), \
+        INCBIN_ALIGNMENT_INDEX)
+
+/* Stringize */
+#define INCBIN_STR(X) \
+    #X
+#define INCBIN_STRINGIZE(X) \
+    INCBIN_STR(X)
+/* Concatenate */
+#define INCBIN_CAT(X, Y) \
+    X ## Y
+#define INCBIN_CONCATENATE(X, Y) \
+    INCBIN_CAT(X, Y)
+/* Deferred macro expansion */
+#define INCBIN_EVAL(X) \
+    X
+#define INCBIN_INVOKE(N, ...) \
+    INCBIN_EVAL(N(__VA_ARGS__))
+/* Variable argument count for overloading by arity */
+#define INCBIN_VA_ARG_COUNTER(_1, _2, _3, N, ...) N
+#define INCBIN_VA_ARGC(...) INCBIN_VA_ARG_COUNTER(__VA_ARGS__, 3, 2, 1, 0)
+
+/* Green Hills uses a different directive for including binary data */
+#if defined(__ghs__)
+#  if (__ghs_asm == 2)
+#    define INCBIN_MACRO ".file"
+/* Or consider the ".myrawdata" entry in the ld file */
+#  else
+#    define INCBIN_MACRO "\tINCBIN"
+#  endif
+#else
+#  define INCBIN_MACRO ".incbin"
+#endif
+
+#ifndef _MSC_VER
+#  define INCBIN_ALIGN \
+    __attribute__((aligned(INCBIN_ALIGNMENT)))
+#else
+#  define INCBIN_ALIGN __declspec(align(INCBIN_ALIGNMENT))
+#endif
+
+#if defined(__arm__) || /* GNU C and RealView */ \
+    defined(__arm) || /* Diab */ \
+    defined(_ARM) /* ImageCraft */
+#  define INCBIN_ARM
+#endif
+
+#ifdef __GNUC__
+/* Utilize .balign where supported */
+#  define INCBIN_ALIGN_HOST ".balign " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".balign 1\n"
+#elif defined(INCBIN_ARM)
+/*
+ * On arm assemblers, the alignment value is calculated as (1 << n) where `n' is
+ * the shift count. This is the value passed to `.align'
+ */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 0\n"
+#else
+/* We assume other inline assembler's treat `.align' as `.balign' */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 1\n"
+#endif
+
+/* INCBIN_CONST is used by incbin.c generated files */
+#if defined(__cplusplus)
+#  define INCBIN_EXTERNAL extern "C"
+#  define INCBIN_CONST    extern const
+#else
+#  define INCBIN_EXTERNAL extern
+#  define INCBIN_CONST    const
+#endif
+
+/**
+ * @brief Optionally override the linker section into which size and data is
+ * emitted.
+ * 
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ */
+#if !defined(INCBIN_OUTPUT_SECTION)
+#  if defined(__APPLE__)
+#    define INCBIN_OUTPUT_SECTION ".const_data"
+#  else
+#    define INCBIN_OUTPUT_SECTION ".rodata"
+#  endif
+#endif
+
+/**
+ * @brief Optionally override the linker section into which data is emitted.
+ *
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ */
+#if !defined(INCBIN_OUTPUT_DATA_SECTION)
+#  define INCBIN_OUTPUT_DATA_SECTION INCBIN_OUTPUT_SECTION
+#endif
+
+/**
+ * @brief Optionally override the linker section into which size is emitted.
+ *
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ * 
+ * @note This is useful for Harvard architectures where program memory cannot
+ * be directly read from the program without special instructions. With this you
+ * can chose to put the size variable in RAM rather than ROM.
+ */
+#if !defined(INCBIN_OUTPUT_SIZE_SECTION)
+#  define INCBIN_OUTPUT_SIZE_SECTION INCBIN_OUTPUT_SECTION
+#endif
+
+#if defined(__APPLE__)
+#  include "TargetConditionals.h"
+#  if defined(TARGET_OS_IPHONE) && !defined(INCBIN_SILENCE_BITCODE_WARNING)
+#    warning "incbin is incompatible with bitcode. Using the library will break upload to App Store if you have bitcode enabled. Add `#define INCBIN_SILENCE_BITCODE_WARNING` before including this header to silence this warning."
+#  endif
+/* The directives are different for Apple branded compilers */
+#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  define INCBIN_INT             ".long "
+#  define INCBIN_MANGLE          "_"
+#  define INCBIN_BYTE            ".byte "
+#  define INCBIN_TYPE(...)
+#else
+#  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  if defined(__ghs__)
+#    define INCBIN_INT           ".word "
+#  else
+#    define INCBIN_INT           ".int "
+#  endif
+#  if defined(__USER_LABEL_PREFIX__)
+#    define INCBIN_MANGLE        INCBIN_STRINGIZE(__USER_LABEL_PREFIX__)
+#  else
+#    define INCBIN_MANGLE        ""
+#  endif
+#  if defined(INCBIN_ARM)
+/* On arm assemblers, `@' is used as a line comment token */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
+#  elif defined(__MINGW32__) || defined(__MINGW64__)
+/* Mingw doesn't support this directive either */
+#    define INCBIN_TYPE(NAME)
+#  else
+/* It's safe to use `@' on other architectures */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", @object\n"
+#  endif
+#  define INCBIN_BYTE            ".byte "
+#endif
+
+/* List of style types used for symbol names */
+#define INCBIN_STYLE_CAMEL 0
+#define INCBIN_STYLE_SNAKE 1
+
+/**
+ * @brief Specify the prefix to use for symbol names.
+ *
+ * @note By default this is "g".
+ *
+ * @code
+ * #define INCBIN_PREFIX incbin
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols instead:
+ * // const unsigned char incbinFoo<data>[];
+ * // const unsigned char *const incbinFoo<end>;
+ * // const unsigned int incbinFoo<size>;
+ * @endcode
+ */
+#if !defined(INCBIN_PREFIX)
+#  define INCBIN_PREFIX g
+#endif
+
+/**
+ * @brief Specify the style used for symbol names.
+ *
+ * Possible options are
+ * - INCBIN_STYLE_CAMEL "CamelCase"
+ * - INCBIN_STYLE_SNAKE "snake_case"
+ *
+ * @note By default this is INCBIN_STYLE_CAMEL
+ *
+ * @code
+ * #define INCBIN_STYLE INCBIN_STYLE_SNAKE
+ * #include "incbin.h"
+ * INCBIN(foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>foo_data[];
+ * // const unsigned char *const <prefix>foo_end;
+ * // const unsigned int <prefix>foo_size;
+ * @endcode
+ */
+#if !defined(INCBIN_STYLE)
+#  define INCBIN_STYLE INCBIN_STYLE_CAMEL
+#endif
+
+/* Style lookup tables */
+#define INCBIN_STYLE_0_DATA Data
+#define INCBIN_STYLE_0_END End
+#define INCBIN_STYLE_0_SIZE Size
+#define INCBIN_STYLE_1_DATA _data
+#define INCBIN_STYLE_1_END _end
+#define INCBIN_STYLE_1_SIZE _size
+
+/* Style lookup: returning identifier */
+#define INCBIN_STYLE_IDENT(TYPE) \
+    INCBIN_CONCATENATE( \
+        INCBIN_STYLE_, \
+        INCBIN_CONCATENATE( \
+            INCBIN_EVAL(INCBIN_STYLE), \
+            INCBIN_CONCATENATE(_, TYPE)))
+
+/* Style lookup: returning string literal */
+#define INCBIN_STYLE_STRING(TYPE) \
+    INCBIN_STRINGIZE( \
+        INCBIN_STYLE_IDENT(TYPE)) \
+
+/* Generate the global labels by indirectly invoking the macro with our style
+ * type and concatenating the name against them. */
+#define INCBIN_GLOBAL_LABELS(NAME, TYPE) \
+    INCBIN_INVOKE( \
+        INCBIN_GLOBAL, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE))) \
+    INCBIN_INVOKE( \
+        INCBIN_TYPE, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE)))
+
+/**
+ * @brief Externally reference binary data included in another translation unit.
+ *
+ * Produces three external symbols that reference the binary data included in
+ * another translation unit.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
+ * @param NAME The name given for the binary data
+ *
+ * @code
+ * INCBIN_EXTERN(Foo);
+ *
+ * // Now you have the following symbols:
+ * // extern const unsigned char <prefix>Foo<data>[];
+ * // extern const unsigned char *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ * 
+ * You may specify a custom optional data type as well as the first argument.
+ * @code
+ * INCBIN_EXTERN(custom_type, Foo);
+ * 
+ * // Now you have the following symbols:
+ * // extern const custom_type <prefix>Foo<data>[];
+ * // extern const custom_type *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ */
+#define INCBIN_EXTERN(...) \
+    INCBIN_CONCATENATE(INCBIN_EXTERN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
+#define INCBIN_EXTERN_1(NAME, ...) \
+    INCBIN_EXTERN_2(unsigned char, NAME)
+#define INCBIN_EXTERN_2(TYPE, NAME) \
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(DATA))[]; \
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE *const \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+        INCBIN_STYLE_IDENT(END)); \
+    INCBIN_EXTERNAL const unsigned int \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(SIZE))
+
+/**
+ * @brief Externally reference textual data included in another translation unit.
+ *
+ * Produces three external symbols that reference the textual data included in
+ * another translation unit.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name given for the textual data
+ *
+ * @code
+ * INCBIN_EXTERN(Foo);
+ *
+ * // Now you have the following symbols:
+ * // extern const char <prefix>Foo<data>[];
+ * // extern const char *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ */
+#define INCTXT_EXTERN(NAME) \
+    INCBIN_EXTERN_2(char, NAME)
+
+/**
+ * @brief Include a binary file into the current translation unit.
+ *
+ * Includes a binary file into the current translation unit, producing three symbols
+ * for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
+ * @param NAME The name to associate with this binary data (as an identifier.)
+ * @param FILENAME The file to include (as a string literal.)
+ *
+ * @code
+ * INCBIN(Icon, "icon.png");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>Icon<data>[];
+ * // const unsigned char *const <prefix>Icon<end>;
+ * // const unsigned int <prefix>Icon<size>;
+ * @endcode
+ * 
+ * You may specify a custom optional data type as well as the first argument.
+ * These macros are specialized by arity.
+ * @code
+ * INCBIN(custom_type, Icon, "icon.png");
+ *
+ * // Now you have the following symbols:
+ * // const custom_type <prefix>Icon<data>[];
+ * // const custom_type *const <prefix>Icon<end>;
+ * // const unsigned int <prefix>Icon<size>;
+ * @endcode
+ *
+ * @warning This must be used in global scope
+ * @warning The identifiers may be different if INCBIN_STYLE is not default
+ *
+ * To externally reference the data included by this in another translation unit
+ * please @see INCBIN_EXTERN.
+ */
+#ifdef _MSC_VER
+#  define INCBIN(NAME, FILENAME) \
+      INCBIN_EXTERN(NAME)
+#else
+#  define INCBIN(...) \
+     INCBIN_CONCATENATE(INCBIN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
+#  if defined(__GNUC__)
+#    define INCBIN_1(...) _Pragma("GCC error \"Single argument INCBIN not allowed\"")
+#  elif defined(__clang__)
+#    define INCBIN_1(...) _Pragma("clang error \"Single argument INCBIN not allowed\"")
+#  else
+#    define INCBIN_1(...) /* Cannot do anything here */
+#  endif
+#  define INCBIN_2(NAME, FILENAME) \
+      INCBIN_3(unsigned char, NAME, FILENAME)
+#  define INCBIN_3(TYPE, NAME, FILENAME) INCBIN_COMMON(TYPE, NAME, FILENAME, /* No terminator for binary data */)
+#  define INCBIN_COMMON(TYPE, NAME, FILENAME, TERMINATOR) \
+    __asm__(INCBIN_SECTION \
+            INCBIN_GLOBAL_LABELS(NAME, DATA) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) ":\n" \
+            INCBIN_MACRO " \"" FILENAME "\"\n" \
+                TERMINATOR \
+            INCBIN_GLOBAL_LABELS(NAME, END) \
+            INCBIN_ALIGN_BYTE \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
+                INCBIN_BYTE "1\n" \
+            INCBIN_GLOBAL_LABELS(NAME, SIZE) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" \
+                INCBIN_INT INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) " - " \
+                           INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) "\n" \
+            INCBIN_ALIGN_HOST \
+            ".text\n" \
+    ); \
+    INCBIN_EXTERN(TYPE, NAME)
+#endif
+
+/**
+ * @brief Include a textual file into the current translation unit.
+ * 
+ * This behaves the same as INCBIN except it produces char compatible arrays
+ * and implicitly adds a null-terminator byte, thus the size of data included
+ * by this is one byte larger than that of INCBIN.
+ *
+ * Includes a textual file into the current translation unit, producing three
+ * symbols for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name to associate with this binary data (as an identifier.)
+ * @param FILENAME The file to include (as a string literal.)
+ *
+ * @code
+ * INCTXT(Readme, "readme.txt");
+ *
+ * // Now you have the following symbols:
+ * // const char <prefix>Readme<data>[];
+ * // const char *const <prefix>Readme<end>;
+ * // const unsigned int <prefix>Readme<size>;
+ * @endcode
+ *
+ * @warning This must be used in global scope
+ * @warning The identifiers may be different if INCBIN_STYLE is not default
+ *
+ * To externally reference the data included by this in another translation unit
+ * please @see INCBIN_EXTERN.
+ */
+#if defined(_MSC_VER)
+#  define INCTXT(NAME, FILENAME) \
+     INCBIN_EXTERN(NAME)
+#else
+#  define INCTXT(NAME, FILENAME) \
+     INCBIN_COMMON(char, NAME, FILENAME, INCBIN_BYTE "0\n")
+#endif
+
+#endif

--- a/src/loader.lisp
+++ b/src/loader.lisp
@@ -24,13 +24,15 @@ after initializing callable symbols[^3].
 [^2]: https://github.com/cffi/cffi/blob/5bfca29deb8b4c214a86ccf37279cc5cea2151e1/src/cffi-sbcl.lisp#L344
 [^3]: https://github.com/sbcl/sbcl/blob/6e2df19952cfc3a526dcc42a5c0f8fa6b571f312/src/code/save.lisp#L83"
   (let ((*initialize-callables-p* t)
+        (*compile-verbose* nil)
         #+darwin
         (initial-thread sb-thread::*initial-thread*))
     #+darwin
     (setf sb-thread::*initial-thread* sb-thread:*current-thread*)
     (unwind-protect
-         (locally
-             (declare (sb-ext:muffle-conditions sb-kernel:redefinition-warning))
+         (handler-bind
+             ((sb-kernel:redefinition-warning #'muffle-warning)
+              (style-warning #'muffle-warning))
            (load pathname))
       #+darwin
       (setf sb-thread::*initial-thread* initial-thread))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -11,6 +11,7 @@
            #:build-bindings
            #:build-python-bindings
            #:build-core-and-die
+           #:create-fasl-library-cmake-project
 
            #:library-c-name
            #:callable-exports


### PR DESCRIPTION
Closes #67.

# Summary
This PR adds the CREATE-FASL-LIBRARY-CMAKE-PROJECT function which generates a CMake project that builds a shared library that contains:

- all the ASDF system dependencies of the target system in FASL form, packed directly into the library using [incbin](https://github.com/graphitemaster/incbin)
- all the callable C symbols declared by the target system
- a library load time hook that loads the packged FASLs into the running Lisp image