### PR TITLE
Allow fatal SBCL errors to be caught

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         repository: sbcl/sbcl
-        ref: sbcl-2.2.4
+        ref: sbcl-2.4.5
         path: sbcl
     - name: install host sbcl
       run: |
@@ -45,4 +45,4 @@ jobs:
         sudo cp libcalc.core /usr/local/lib
         echo "(+ 1 2)" | ./example | tr -d '\n' | grep "> 3> "
         echo "(+ 1 2)" | python ./example.py | tr -d '\n' | grep "> 3> "
-   
+        python ./exhaust_heap.py | grep "returned to Python with error code 2 after heap exhaustion"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         repository: sbcl/sbcl
-        ref: ${{ matrix.arch == 'arm64' && 'sbcl-2.2.4' || 'x86-null-tn' }}
+        ref: ${{ matrix.arch == 'arm64' && 'sbcl-2.4.5' || 'x86-null-tn' }}
         path: sbcl
     - name: install host sbcl
       run: brew install sbcl
@@ -46,4 +46,4 @@ jobs:
         gcc -Wall -o example example.c -lcalc -lsbcl
         echo "(+ 1 2)" | ./example | tr -d '\n' | grep "> 3> "
         echo "(+ 1 2)" | python3 ./example.py | tr -d '\n' | grep "> 3> "
-   
+        python3 ./exhaust_heap.py | grep "returned to Python with error code 2 after heap exhaustion"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         repository: sbcl/sbcl
-        ref: sbcl-2.4.4
+        ref: sbcl-2.4.5
         path: sbcl
     - uses: msys2/setup-msys2@v2
       with:
@@ -54,3 +54,4 @@ jobs:
         cp libcalc.core $MSYSTEM_PREFIX/bin
         echo "(+ 1 2)" | ./example.exe | tr -d '\r\n' | grep "> 3> "
         echo "(+ 1 2)" | python ./example.py | tr -d '\r\n' | grep "> 3> "
+        python ./exhaust_heap.py | grep "returned to Python with error code 2 after heap exhaustion"

--- a/examples/libcalc/exhaust_heap.py
+++ b/examples/libcalc/exhaust_heap.py
@@ -1,0 +1,10 @@
+import libcalc
+import sys
+
+
+if __name__ == '__main__':
+    result = libcalc.calc_exhaust_heap()
+    # Attempting to call into Lisp again should return the same error code
+    assert(libcalc.calc_exhaust_heap() == result)
+    if result == 2:
+        print("returned to Python with error code %d after heap exhaustion" % result)

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -7,10 +7,9 @@
 
 (in-package #:sbcl-librarian/example/libcalc)
 
-(let ((sbcl-librarian::*non-static-lossage-handler* t))
-  (build-bindings libcalc ".")
-  (build-python-bindings libcalc "." #+github-ci :library-path
-                                     #+(and github-ci win32) (concatenate 'string (uiop:getenv "MSYSTEM_PREFIX") "/bin/libcalc.dll")
-                                     #+(and github-ci linux) "/usr/local/lib/libcalc.so"
-                                     #+(and github-ci darwin) nil)
-  (build-core-and-die libcalc "." :compression nil))
+(build-bindings libcalc ".")
+(build-python-bindings libcalc "." #+github-ci :library-path
+                                   #+(and github-ci win32) (concatenate 'string (uiop:getenv "MSYSTEM_PREFIX") "/bin/libcalc.dll")
+                                   #+(and github-ci linux) "/usr/local/lib/libcalc.so"
+                                   #+(and github-ci darwin) nil)
+(build-core-and-die libcalc "." :compression nil))

--- a/src/function.lisp
+++ b/src/function.lisp
@@ -1,13 +1,27 @@
 (in-package #:sbcl-librarian)
 
+(defparameter *longjmp-operator*
+  #-win32 "longjmp" #+win32 "__builtin_longjmp"
+  "The name of the function/macro/builtin that implements longjmp. Note
+that we use __builtin_longjmp on Windows because, unlike the longjmp
+provided by the UCRT, it does not perform stack unwinding, which does
+not work with Lisp stack frames.")
+
+(defparameter *setjmp-operator*
+  #-win32 "setjmp" #+win32 "__builtin_setjmp"
+  "The name of the function/macro/builtin that implements longjmp. See
+the documentation for *longjmp-operator* for rationale.")
+
 (defvar *initialize-callables-p* nil
   "Bound to T when we are loading Lisp and want to reinitialize
   callables on load.")
 
 (defun canonical-signature (name result-type typed-lambda-list &key
                                                                  (function-prefix "")
+                                                                 (c-prefix "")
                                                                  error-map)
-  (let* ((callable-name (prefix-name function-prefix name))
+  (let* ((callable-name (callable-name-with-c-prefix (prefix-name function-prefix name)
+                                                     c-prefix))
          (return-type
            (if error-map
                (error-map-type error-map)
@@ -24,11 +38,13 @@
                                &key (datap 't) (externp nil)
                                     (linkage nil)
                                     (function-prefix "")
-                                    error-map)
+                                    (c-prefix "")
+                                 error-map)
   (multiple-value-bind (callable-name return-type typed-lambda-list result-type)
       (canonical-signature name result-type typed-lambda-list
                            :function-prefix function-prefix
-                           :error-map error-map)    
+                           :c-prefix c-prefix
+                           :error-map error-map)
     (format nil "~:[~;extern ~]~@[~a ~]~a ~:[~a~;(*~a)~](~{~a~^, ~})"
             externp
             linkage
@@ -43,6 +59,55 @@
                      typed-lambda-list)
              (and result-type
                   (list (format nil "~a *result" (c-type result-type))))))))
+
+(defun c-function-definition (name result-type typed-lambda-list
+                              &key (function-prefix "")
+                                error-map)
+  "Returns a string constituting a C definition for a function called
+NAME that implements the function declaration produced by calling
+C-FUNCTION-DECLARATION on the provided arguments. The function body
+forwards the function arguments to a call to a function pointer with
+the same name as the function, except with a leading underscore.
+
+The call to the function pointer is wrapped as follows:
+
+if (!setjmp(fatal_lisp_error_handler)) {
+    // function pointer call
+} else {
+    return FATAL_ERROR_CODE;  // or ldb_monitor();, which
+                              // drops into LDB, if ERROR-MAP does not
+                              // have a FATAL-ERROR
+}"
+  (let ((header (c-function-declaration name result-type typed-lambda-list
+                                        :datap nil :externp nil :linkage nil
+                                        :function-prefix function-prefix :error-map error-map)))
+    (multiple-value-bind (callable-name return-type typed-lambda-list result-type)
+        (canonical-signature name result-type typed-lambda-list
+                             :function-prefix function-prefix
+                             :error-map error-map)
+      (declare (ignore return-type))
+      (let ((call-statement (format nil "return ~a(~{~a~^, ~});"
+                                    (concatenate 'string "_" (coerce-to-c-name callable-name))
+                                    (append
+                                     (mapcar (lambda (item)
+                                               (lisp-to-c-name (first item)))
+                                             typed-lambda-list)
+                                     (and result-type
+                                          (list "result"))))))
+        (format nil "~a {~%~a~%}~%"
+                header
+                (format nil "    if (!fatal_sbcl_error_occurred && !~a(fatal_lisp_error_handler)) {
+        ~a
+    } else {
+        ~a
+    }"
+                        *setjmp-operator*
+                        call-statement
+                        ;; If the error map does not have specify a
+                        ;; fatal error code, then drop into LDB.
+                        (if (and error-map (error-map-fatal-code error-map))
+                            (format nil "return ~d;" (error-map-fatal-code error-map))
+                            (format nil "ldb_monitor();"))))))))
 
 (defun callable-definition (name result-type typed-lambda-list &key
                                                                  (function-prefix "")
@@ -62,7 +127,7 @@
                              :error-map error-map)
       `(progn
          (sb-alien:define-alien-callable
-             ,callable-name
+             ,(callable-name-with-c-prefix callable-name "_")
              ,(sb-alien-type return-type)
              (,@(loop :for (arg type) :in typed-lambda-list
                       :collect (list arg (sb-alien-type type)))
@@ -80,4 +145,4 @@
                     (wrap-error-handling result error-map)
                     result))))
          (when *initialize-callables-p*
-           (sb-alien::initialize-alien-callable-symbol ',callable-name))))))
+           (sb-alien::initialize-alien-callable-symbol ',(callable-name-with-c-prefix callable-name "_")))))))

--- a/src/library.lisp
+++ b/src/library.lisp
@@ -60,7 +60,7 @@ NOTE: Here, the APIs must already be defined elsewhere."
     (loop :for (kind . things) :in (api-specs api)
           :when (eq kind ':function)
             :append (mapcar (lambda (spec)
-                              (prefix-name (api-function-prefix api) (first spec)))
+                              (callable-name-with-c-prefix (prefix-name (api-function-prefix api) (first spec)) "_"))
                             things))))
 
 (defun build-core-and-die (library directory &key compression)

--- a/src/python-bindings.lisp
+++ b/src/python-bindings.lisp
@@ -10,16 +10,23 @@
                            :function-prefix function-prefix
                            :error-map error-map)
     (format nil
-            "~a = CFUNCTYPE(~a, ~{~a~^, ~})(c_void_p.in_dll(~a, '~a').value)"
+            "~a = ~a.~a
+~a.restype = ~a
+~a.argtypes = [~{~a~^, ~}]"
+            ;; First line
+            (coerce-to-c-name callable-name)
+            library-name
+            (coerce-to-c-name callable-name)
+            ;; Second line
             (coerce-to-c-name callable-name)
             (python-type return-type)
+            ;; Third line
+            (coerce-to-c-name callable-name)
             (append
              (loop :for (name type) :in typed-lambda-list
                    :collect (python-type type))
              (and result-type
-                  (list (format nil "POINTER(~a)" (python-type result-type)))))
-            library-name
-            (coerce-to-c-name callable-name))))
+                  (list (format nil "POINTER(~a)" (python-type result-type))))))))
 
 (defun write-default-python-header (library stream &optional (omit-init-call nil)
                                                              (library-path nil))


### PR DESCRIPTION
## Problem
A call into Lisp may trigger a fatal error in SBCL, dropping the process unceremoniously into LDB and making it difficult for the user to gracefully terminate the process.

## Solution
Use `setjmp` to save the execution context before calling into Lisp, and use `longjmp` to return to the pre-call execution context with a special error code if a fatal SBCL error was encountered.

## Notes
- ~~**This feature requires patching SBCL to make the `lossage_handler` function pointer non-static, setting `sbcl-librarian::*non-static-lossage-handler*` to `T`, and adding a `fatal-error` code to the error map.**~~ **`set_lossage_handler` exists and is exported by the runtime**
- `DEFINE-ERROR-TYPE` takes a new `fatal-error` argument specifying which value to return when a Lisp call triggers a fatal SBCL error.
- The names of the function pointers in the generated C bindings are now prefixed with an underscore.
- Each function pointer is wrapped by a function definition with the original callable name. The body of each function definition performs a `setjmp` before calling into Lisp through the associated function pointer.
- If there is no `error-map` or no `fatal-code` is specified, then the fatal error handler just drops into LDB.