### PR TITLE
Prefer sb-sys:int-sap

### DIFF
--- a/src/handles.lisp
+++ b/src/handles.lisp
@@ -7,7 +7,7 @@
 (defvar *handles* (vector (make-hash-table :synchronized t) 0))
 
 ;; coerce int key to void* handle
-(defun key-handle (key) (sb-alien:sap-alien (sb-int::int-sap key) (* t)))
+(defun key-handle (key) (sb-alien:sap-alien (sb-sys:int-sap key) (* t)))
 (defun handle-key (handle) (sb-alien::sap-int (sb-alien:alien-sap handle)))
 
 (defvar *handle-lock*


### PR DESCRIPTION
A recent change to sbcl reduces the number of symbols imported by sb-int which will cause sb-int::int-sap to fail. This change is backward compatible.

The sbcl commit was:

https://github.com/sbcl/sbcl/commit/8438fc57bb83637ef7f177e8f467183df8e9e932