### PR TITLE
Add Python example to CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,6 +43,6 @@ jobs:
         gcc -Wall -o example example.c -lcalc -lsbcl
         sudo mv libcalc.so /usr/local/lib
         sudo cp libcalc.core /usr/local/lib
-        echo "(+ 1 2)" | ./example
-        echo "(+ 1 2)" | python ./example.py
+        echo "(+ 1 2)" | ./example | tr -d '\n' | grep "> 3> "
+        echo "(+ 1 2)" | python ./example.py | tr -d '\n' | grep "> 3> "
    

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,12 +34,15 @@ jobs:
       working-directory: examples/libcalc
       env:
         SBCL_SRC: ${{ github.workspace }}/../sbcl
-        LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime:.
-        LD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime:.
+        LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime:${{ github.workspace }}/examples/libcalc
+        LD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime:/usr/local/lib
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
       run: |
         $SBCL_SRC/run-sbcl.sh --script script.lisp
         gcc -Wall -fPIC -shared -o libcalc.so libcalc.c -lsbcl
         gcc -Wall -o example example.c -lcalc -lsbcl
+        sudo mv libcalc.so /usr/local/lib
+        sudo cp libcalc.core /usr/local/lib
         echo "(+ 1 2)" | ./example
+        echo "(+ 1 2)" | python ./example.py
    

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -45,4 +45,5 @@ jobs:
         gcc -Wall -fPIC -shared -o libcalc.dylib libcalc.c -lsbcl
         gcc -Wall -o example example.c -lcalc -lsbcl
         echo "(+ 1 2)" | ./example
+        echo "(+ 1 2)" | python3 ./example.py
    

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -44,6 +44,6 @@ jobs:
         $SBCL_SRC/run-sbcl.sh --script script.lisp
         gcc -Wall -fPIC -shared -o libcalc.dylib libcalc.c -lsbcl
         gcc -Wall -o example example.c -lcalc -lsbcl
-        echo "(+ 1 2)" | ./example
-        echo "(+ 1 2)" | python3 ./example.py
+        echo "(+ 1 2)" | ./example | tr -d '\n' | grep "> 3> "
+        echo "(+ 1 2)" | python3 ./example.py | tr -d '\n' | grep "> 3> "
    

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,5 +52,5 @@ jobs:
         gcc -Wall -o example example.c -lcalc -L.
         mv libcalc.dll $MSYSTEM_PREFIX/bin
         cp libcalc.core $MSYSTEM_PREFIX/bin
-        echo "(+ 1 2)" | ./example.exe
-        echo "(+ 1 2)" | python ./example.py
+        echo "(+ 1 2)" | ./example.exe | tr -d '\r\n' | grep "> 3> "
+        echo "(+ 1 2)" | python ./example.py | tr -d '\r\n' | grep "> 3> "

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,10 +44,13 @@ jobs:
       working-directory: examples/libcalc
       env:
         SBCL_SRC: ${{ github.workspace }}/../sbcl
-        LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime;.
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
+        MSYS2_PATH_TYPE: inherit
       run: |
         $SBCL_SRC/run-sbcl.sh --script script.lisp
-        gcc -Wall -fPIC -shared -o libcalc.dll libcalc.c -Wl,--export-all-symbols -Wl,--whole-archive -lsbcl -Wl,--no-whole-archive -ladvapi32 -lsynchronization -lws2_32 -lzstd
-        gcc -Wall -o example example.c -lcalc
+        gcc -Wall -fPIC -shared -Wl,--export-all-symbols -o libcalc.dll libcalc.c -Wl,--whole-archive $SBCL_SRC/src/runtime/libsbcl.a -Wl,--no-whole-archive -ladvapi32 -lsynchronization -lws2_32 -lzstd
+        gcc -Wall -o example example.c -lcalc -L.
+        mv libcalc.dll $MSYSTEM_PREFIX/bin
+        cp libcalc.core $MSYSTEM_PREFIX/bin
         echo "(+ 1 2)" | ./example.exe
+        echo "(+ 1 2)" | python ./example.py

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -2,9 +2,15 @@
 
 (asdf:load-system '#:libcalc)
 
+(when (uiop:getenv "CI")
+  (push :github-ci *features*))
 
 (in-package #:sbcl-librarian/example/libcalc)
 
-(build-bindings libcalc ".")
-(build-python-bindings libcalc ".")
-(build-core-and-die libcalc "." :compression nil)
+(let ((sbcl-librarian::*non-static-lossage-handler* t))
+  (build-bindings libcalc ".")
+  (build-python-bindings libcalc "." #+github-ci :library-path
+                                     #+(and github-ci win32) (concatenate 'string (uiop:getenv "MSYSTEM_PREFIX") "/bin/libcalc.dll")
+                                     #+(and github-ci linux) "/usr/local/lib/libcalc.so"
+                                     #+(and github-ci darwin) nil)
+  (build-core-and-die libcalc "." :compression nil))


### PR DESCRIPTION
## Notes
- libcalc's example.py is now run in CI.
- I could not get `ctypes.util.find_library` to work in either of the Windows or Linux CI jobs, so this PR also adds an option to generate Python bindings with a hard-coded path to the shared library.