### PR TITLE
Fix fatal error handling for Clang + add Windows Clang workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         repository: sbcl/sbcl
-        ref: sbcl-2.4.5
+        ref: sbcl-2.4.6
         path: sbcl
     - name: install host sbcl
       run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         repository: sbcl/sbcl
-        ref: ${{ matrix.arch == 'arm64' && 'sbcl-2.4.5' || 'x86-null-tn' }}
+        ref: ${{ matrix.arch == 'arm64' && 'sbcl-2.4.6' || 'x86-null-tn' }}
         path: sbcl
     - name: install host sbcl
       run: brew install sbcl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,12 @@ jobs:
 
     runs-on: windows-latest
 
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+      fail-fast: false
+
     defaults:
       run:
         shell: msys2 {0}
@@ -16,11 +22,11 @@ jobs:
     - uses: actions/checkout@v1
       with:
         repository: sbcl/sbcl
-        ref: sbcl-2.4.5
+        ref: sbcl-2.4.6
         path: sbcl
     - uses: msys2/setup-msys2@v2
       with:
-        install: mingw-w64-x86_64-gcc make diffutils git python3
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-clang mingw-w64-x86_64-lld make diffutils git python3 dos2unix
 
     - name: install host sbcl
       shell: pwsh
@@ -34,7 +40,9 @@ jobs:
       run: |
         PATH=$PATH:"/c/Program Files/Steel Bank Common Lisp/1.4.14"
         export PATH
-        ./make.sh --xc-host='sbcl --lose-on-corruption --disable-ldb --disable-debugger' --with-sb-linkable-runtime
+        dos2unix '${{ github.workspace }}\patches\win32-clang-build.patch'
+        if [ "clang" = "${{ matrix.cc }}" ]; then git apply --verbose '${{ github.workspace }}\patches\win32-clang-build.patch'; fi
+        CC=${{ matrix.cc }} ./make.sh --xc-host='sbcl --lose-on-corruption --disable-ldb --disable-debugger' --with-sb-linkable-runtime
     - name: install quicklisp
       working-directory: ../sbcl
       run: |
@@ -48,8 +56,8 @@ jobs:
         MSYS2_PATH_TYPE: inherit
       run: |
         $SBCL_SRC/run-sbcl.sh --script script.lisp
-        gcc -Wall -fPIC -shared -Wl,--export-all-symbols -o libcalc.dll libcalc.c -Wl,--whole-archive $SBCL_SRC/src/runtime/libsbcl.a -Wl,--no-whole-archive -ladvapi32 -lsynchronization -lws2_32 -lzstd
-        gcc -Wall -o example example.c -lcalc -L.
+        ${{ matrix.cc }} -Wall -fPIC -shared -Wl,--export-all-symbols -o libcalc.dll libcalc.c -Wl,--whole-archive $SBCL_SRC/src/runtime/libsbcl.a -Wl,--no-whole-archive -ladvapi32 -lsynchronization -lws2_32 -lzstd
+        ${{ matrix.cc }} -Wall -o example example.c -lcalc -L.
         mv libcalc.dll $MSYSTEM_PREFIX/bin
         cp libcalc.core $MSYSTEM_PREFIX/bin
         echo "(+ 1 2)" | ./example.exe | tr -d '\r\n' | grep "> 3> "

--- a/patches/win32-clang-build.patch
+++ b/patches/win32-clang-build.patch
@@ -1,0 +1,58 @@
+From 4a4dc050d49789e60ab3a71ea85502caf42755e4 Mon Sep 17 00:00:00 2001
+From: Kartik Singh <kssingh@hrl.com>
+Date: Fri, 5 Jul 2024 14:22:35 -0700
+Subject: [PATCH] Support Clang + PDB on Windows
+
+---
+ src/runtime/Config.x86-64-win32 | 18 ++++++++++++++++--
+ src/runtime/hopscotch.c         |  3 +--
+ 2 files changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/src/runtime/Config.x86-64-win32 b/src/runtime/Config.x86-64-win32
+index 3c922ffd3..b2c75ddd0 100644
+--- a/src/runtime/Config.x86-64-win32
++++ b/src/runtime/Config.x86-64-win32
+@@ -56,10 +56,24 @@ CFLAGS += -g -W -Wall \
+        -Wno-unused-function -Wno-unused-parameter -Wno-cast-function-type \
+        -Wno-type-limits \
+        -fno-omit-frame-pointer \
+-       -O5 -m64 -DWINVER=0x0501 \
++       -O3 -m64 -DWINVER=0x0501 \
+        -D__W32API_USE_DLLIMPORT__
+ 
+-CC = gcc
++CC ?= gcc
++
++ifeq ($(CC),clang)
++ifneq ($(shell ld.lld --version | head -n 1 | grep LLD),)
++LD=ld.lld
++CFLAGS += -fuse-ld=lld
++endif
++endif
++
++ifeq ($(shell $(CC) -gcodeview 2>&1 | grep codeview),)
++ifeq ($(shell $(LD) -pdb= 2>&1 | grep -- -pdb=),)
++CFLAGS += -gcodeview
++LINKFLAGS += -Wl,-pdb=
++endif
++endif
+ 
+ ifeq ($(shell $(LD) --disable-dynamicbase 2>&1 | grep disable-dynamicbase),)
+ LINKFLAGS += -Wl,--disable-dynamicbase
+diff --git a/src/runtime/hopscotch.c b/src/runtime/hopscotch.c
+index 0c8330d65..ccbb53ddc 100644
+--- a/src/runtime/hopscotch.c
++++ b/src/runtime/hopscotch.c
+@@ -22,8 +22,7 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #ifdef LISP_FEATURE_WIN32
+-/* I don't know where ffs() is prototyped */
+-extern int ffs(int);
++#define ffs(x) __builtin_ffs(x)
+ #else
+ /* https://www.freebsd.org/cgi/man.cgi?query=fls&sektion=3&manpath=FreeBSD+7.1-RELEASE
+    says strings.h */
+-- 
+2.32.1 (Apple Git-133)
+

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -131,14 +131,22 @@
       ;; use a jump buffer of type intptr_t[5] instead of jmp_buf (see
       ;; https://gcc.gnu.org/onlinedocs/gcc/Nonlocal-Gotos.html).
       #-win32
-      (format stream "__thread jmp_buf fatal_lisp_error_handler;~%~%")
+      (format stream "__thread jmp_buf fatal_lisp_error_handler;~%")
       #+win32
-      (format stream "__thread intptr_t fatal_lisp_error_handler[5];~%~%")
+      (format stream "__thread intptr_t fatal_lisp_error_handler[5];~%")
+      ;; Clang's __builtin_{set,long}jmp are compatibile with the GCC
+      ;; equivalents[^1]. However, Clang types the jmp_buf arguments
+      ;; to these builtins as `(void **)` instead of `intptr[5]`[^2],
+      ;; so we add a macro to conditionally insert the cast.
+      ;;
+      ;; [^1]: https://github.com/llvm/llvm-project/blob/ceade83ad5fc529f2b2beb896eec0dd0b29fdd44/llvm/docs/ExceptionHandling.rst#id32
+      ;; [^2]: https://github.com/llvm/llvm-project/blob/ceade83ad5fc529f2b2beb896eec0dd0b29fdd44/clang/include/clang/Basic/Builtins.td#L897
+      (format stream "#ifdef __clang__~%# define JMP_BUF_CAST (void **)~%#else~%# define JMP_BUF_CAST~%#endif~%~%")
       (when (sb-sys:find-foreign-symbol-address "set_lossage_handler")
         (format stream "void set_lossage_handler(void (*handler)(void));~%"))
       (format stream "void ldb_monitor(void);~%~%")
       (format stream "int fatal_sbcl_error_occurred = 0;~%~%")
-      (format stream "void return_from_lisp(void) { fatal_sbcl_error_occurred = 1; fflush(stdout); fflush(stderr); ~a(fatal_lisp_error_handler, 1); }~%~%"
+      (format stream "void return_from_lisp(void) { fatal_sbcl_error_occurred = 1; fflush(stdout); fflush(stderr); ~a(JMP_BUF_CAST fatal_lisp_error_handler, 1); }~%~%"
               *longjmp-operator*)
       (dolist (api (library-apis library))
         (write-api-to-source api stream))

--- a/src/function.lisp
+++ b/src/function.lisp
@@ -96,7 +96,7 @@ if (!setjmp(fatal_lisp_error_handler)) {
                                           (list "result"))))))
         (format nil "~a {~%~a~%}~%"
                 header
-                (format nil "    if (!fatal_sbcl_error_occurred && !~a(fatal_lisp_error_handler)) {
+                (format nil "    if (!fatal_sbcl_error_occurred && !~a(JMP_BUF_CAST fatal_lisp_error_handler)) {
         ~a
     } else {
         ~a


### PR DESCRIPTION
This PR casts the `jmp_buf` argument of `__builtin_setjmp` and `__builtin_longjmp` to `(void **)` on Clang (see comment in `src/bindings.lisp` for rationale).

Also adds a Clang build + test to the Windows workflow (this currently requires a patch to SBCL, which is included), and updates the SBCL versions used on all platform workflows to 2.4.6.