### PR TITLE
Allow building libsbcl_librarian without SBCL source

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,7 +45,7 @@ jobs:
         LD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
       run: |
         conda install -y conda-build
-        conda build recipe --output-folder conda-bld
+        conda build recipe --output-folder conda-bld -e recipe/ci_build_config.yaml
         conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian
     - name: set environment variables
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash -el {0}
+
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v1
@@ -14,6 +18,9 @@ jobs:
         repository: sbcl/sbcl
         ref: sbcl-2.4.6
         path: sbcl
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        channels: conda-forge
     - name: install host sbcl
       run: |
         sudo apt-get -qq update | true
@@ -32,31 +39,16 @@ jobs:
       run: |
         curl -O https://beta.quicklisp.org/quicklisp.lisp
         ./run-sbcl.sh --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" --eval "(ql-util:without-prompting (ql:add-to-init-file))" --eval "(quit)"
-    - name: install conda
-      run: |
-        mkdir -p ~/miniconda3
-        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-        bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-        rm ~/miniconda3/miniconda.sh
-    - name: install conda-build
-      run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
-        conda config --add channels conda-forge
-        conda install -y conda-build
     - name: build and install conda package
       env:
         LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
         LD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
       run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
+        conda install -y conda-build
         conda build recipe --output-folder conda-bld
         conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian
     - name: set environment variables
       run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
         echo "LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib:$CONDA_PREFIX/lib64" >> "$GITHUB_ENV"
         echo "LD_LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib:$CONDA_PREFIX/lib64" >> "$GITHUB_ENV"
         echo "C_INCLUDE_PATH=$CONDA_PREFIX/include" >> "$GITHUB_ENV"
@@ -65,8 +57,6 @@ jobs:
       env:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
       run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
         $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         pushd libcalc
         mkdir build

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -12,6 +12,10 @@ jobs:
         arch: [arm64]
       fail-fast: false
 
+    defaults:
+      run:
+        shell: bash -el {0}
+
     steps:
     - uses: actions/checkout@v1
     - uses: actions/checkout@v1
@@ -19,6 +23,9 @@ jobs:
         repository: sbcl/sbcl
         ref: ${{ matrix.arch == 'arm64' && 'sbcl-2.4.6' || 'x86-null-tn' }}
         path: sbcl
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        channels: conda-forge
     - name: install host sbcl
       run: brew install sbcl
     - name: build
@@ -35,31 +42,16 @@ jobs:
       run: |
         curl -O https://beta.quicklisp.org/quicklisp.lisp
         ./run-sbcl.sh --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" --eval "(ql-util:without-prompting (ql:add-to-init-file))" --eval "(quit)"
-    - name: install conda
-      run: |
-        mkdir -p ~/miniconda3
-        curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o ~/miniconda3/miniconda.sh
-        bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-        rm ~/miniconda3/miniconda.sh
-    - name: install conda-build
-      run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
-        conda config --add channels conda-forge
-        conda install -y conda-build
     - name: build and install conda package
       env:
         LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
         DYLD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
       run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
+        conda install -y conda-build
         conda build recipe --output-folder conda-bld
         conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian
     - name: set environment variables
       run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
         echo "LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib" >> "$GITHUB_ENV"
         echo "DYLD_LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib" >> "$GITHUB_ENV"
         echo "C_INCLUDE_PATH=$CONDA_PREFIX/include" >> "$GITHUB_ENV"
@@ -68,8 +60,6 @@ jobs:
       env:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
       run: |
-        source ~/miniconda3/etc/profile.d/conda.sh
-        conda activate
         $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         pushd libcalc
         mkdir build

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -48,7 +48,7 @@ jobs:
         DYLD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
       run: |
         conda install -y conda-build
-        conda build recipe --output-folder conda-bld
+        conda build recipe --output-folder conda-bld -e recipe/ci_build_config.yaml
         conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian
     - name: set environment variables
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,7 +64,7 @@ jobs:
       shell: pwsh
       run: |
         conda install conda-build
-        conda build recipe --output-folder conda-bld
+        conda build recipe --output-folder conda-bld -e recipe/ci_build_config.yaml
         conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian python
     - name: set environment variables
       shell: pwsh

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,7 +16,7 @@ if(WIN32)
 endif(WIN32)
 
 if(DEFINED ENV{SBCL_SRC})
-    set(SBCL "$ENV{SBCL_SRC}/run-sbcl.sh")
+    set(SBCL sh "$ENV{SBCL_SRC}/run-sbcl.sh")
 else()
     set(SBCL "sbcl")
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,7 +16,7 @@ if(WIN32)
 endif(WIN32)
 
 if(DEFINED ENV{SBCL_SRC})
-    set(SBCL "sh $ENV{SBCL_SRC}/run-sbcl.sh")
+    set(SBCL "$ENV{SBCL_SRC}/run-sbcl.sh")
 else()
     set(SBCL "sbcl")
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,10 +15,16 @@ if(WIN32)
   set_target_properties(sbcl_librarian PROPERTIES PREFIX "")
 endif(WIN32)
 
+if(DEFINED ENV{SBCL_SRC})
+    set(SBCL "sh $ENV{SBCL_SRC}/run-sbcl.sh")
+else()
+    set(SBCL "sbcl")
+endif()
+
 # Generate the core file and C bindings
 add_custom_command(
   OUTPUT sbcl_librarian.c sbcl_librarian.h
-  COMMAND ${CMAKE_COMMAND} -E env CL_SOURCE_REGISTRY=${CMAKE_CURRENT_SOURCE_DIR}/..// sh $ENV{SBCL_SRC}/run-sbcl.sh --script ${CMAKE_CURRENT_SOURCE_DIR}/generate-bindings.lisp
+  COMMAND ${CMAKE_COMMAND} -E env CL_SOURCE_REGISTRY=${CMAKE_CURRENT_SOURCE_DIR}/..// ${SBCL} --script ${CMAKE_CURRENT_SOURCE_DIR}/generate-bindings.lisp
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 

--- a/recipe/ci_build_config.yaml
+++ b/recipe/ci_build_config.yaml
@@ -1,0 +1,7 @@
+python:
+  - 3.12
+
+c_compiler:    # [win]
+- vs2022       # [win]
+cxx_compiler:  # [win]
+- vs2022       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,11 @@ build:
 
 requirements:
   build:
-#    - {{ compiler('c') }}
-#    - {{ compiler('cxx') }}
     - python
     - cmake
+{% if not environ.get('SBCL_SRC') %}
+    - sbcl={{ environ.get('CONDA_BUILD_SBCL_VERSION', '2.4.0') }}
+{% endif %}
   host:
     - python {{ python }}
   run:


### PR DESCRIPTION
# Summary
This PR handles the case where the `SBCL_SRC` environment variable is not set:
- the `sbcl` Conda package is installed as a build dependency when building the `sbcl-librarian` package
- CMake uses the `sbcl` binary present in the path to run `generate-bindings.lisp`

It also cleans up the Linux and macOS workflows by using the `setup-miniconda@v3` action.