### PR TITLE
Only read incbin when.h :compile-toplevel

### DIFF
--- a/src/fasl-lib.lisp
+++ b/src/fasl-lib.lisp
@@ -1,6 +1,6 @@
 (in-package #:sbcl-librarian)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
+(eval-when (:compile-toplevel)
   (defparameter *incbin-filename* "incbin.h"
     "The name of the file containing the incbin source code.")
   (defparameter *incbin-source-text*


### PR DESCRIPTION
This should make it so that we only read incbin.h at compile-time.