### PR TITLE
Remove swank dependency

### DIFF
--- a/sbcl-librarian.asd
+++ b/sbcl-librarian.asd
@@ -7,7 +7,6 @@
   ; :version "0.0.1"
   :in-order-to ((test-op (test-op "sbcl-librarian/tests")))
   :depends-on (#:sb-sprof
-               #:swank
                )
   :serial t
   :pathname "src/"

--- a/src/diagnostics.lisp
+++ b/src/diagnostics.lisp
@@ -23,7 +23,7 @@
 
 (defun start-swank-server (port)
   (sb-ext:enable-debugger)
-  (swank:create-server :port port :dont-close t)
+  (uiop:symbol-call "SWANK" "CREATE-SERVER" :port port :dont-close t)
   (values))
 
 (defun perform-gc ()


### PR DESCRIPTION
This PR removes the swank dependency in the ASDF system definition by calling into swank via uiop:symbol-call.