### PR TITLE
Move *incbin-filename* into separate eval-when

### DIFF
--- a/src/fasl-lib.lisp
+++ b/src/fasl-lib.lisp
@@ -1,8 +1,10 @@
 (in-package #:sbcl-librarian)
 
-(eval-when (:compile-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *incbin-filename* "incbin.h"
-    "The name of the file containing the incbin source code.")
+    "The name of the file containing the incbin source code."))
+
+(eval-when (:compile-toplevel)
   (defparameter *incbin-source-text*
     (uiop:read-file-string
      (asdf:system-relative-pathname "sbcl-librarian"


### PR DESCRIPTION
I'm getting this error when building something against sbcl-librarian:

```
Unhandled UNBOUND-VARIABLE in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                        {7005373AC3}>:
  The variable SBCL-LIBRARIAN::*INCBIN-FILENAME* is unbound.
```

This PR attempts to fix this by moving `*INCBIN-FILENAME*` into an `(eval-when (:compile-toplevel :load-toplevel :execute) ...)`.