### PR TITLE
Make incbin parameters constants

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         conda install -y conda-build
         conda build recipe --output-folder conda-bld
-        conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian
+        conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian python=3.12
     - name: set environment variables
       run: |
         echo "LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib:$CONDA_PREFIX/lib64" >> "$GITHUB_ENV"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         conda install -y conda-build
         conda build recipe --output-folder conda-bld
-        conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian
+        conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian python=3.12
     - name: set environment variables
       run: |
         echo "LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib" >> "$GITHUB_ENV"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         conda install conda-build
         conda build recipe --output-folder conda-bld
-        conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian
+        conda install -c ${{ github.workspace }}/conda-bld/ sbcl-librarian python=3.12
     - name: set environment variables
       shell: pwsh
       run: |

--- a/src/fasl-lib.lisp
+++ b/src/fasl-lib.lisp
@@ -1,15 +1,20 @@
 (in-package #:sbcl-librarian)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (defparameter *incbin-filename* "incbin.h"
-    "The name of the file containing the incbin source code."))
+  (defconstant +incbin-filename+
+    (if (boundp '+incbin-filename+)
+        +incbin-filename+
+        "incbin.h")
+    "The name of the file containing the incbin source code.")
 
-(eval-when (:compile-toplevel)
-  (defparameter *incbin-source-text*
-    (uiop:read-file-string
-     (asdf:system-relative-pathname "sbcl-librarian"
-                                    (uiop:merge-pathnames* *incbin-filename* "src/")))
+  (defconstant +incbin-source-text+
+    (if (boundp '+incbin-source-text+)
+        +incbin-source-text+
+        (uiop:read-file-string
+         (asdf:system-relative-pathname "sbcl-librarian"
+                                        (uiop:merge-pathnames* +incbin-filename+ "src/"))))
     "The full source code of incbin."))
+
 
 (defparameter *fasl-loader-filename* "fasl_loader.c"
   "The name of the C source file that contains both embedded FASLs and a
@@ -55,8 +60,8 @@ skipping those for already-loaded systems."
 
 (defun create-incbin-source-file (directory)
   "Copy the incbin source code to DIRECTORY."
-  (with-open-file (stream (uiop:merge-pathnames* *incbin-filename* directory) :direction :output :if-exists :supersede)
-    (format stream *incbin-source-text*)))
+  (with-open-file (stream (uiop:merge-pathnames* +incbin-filename+ directory) :direction :output :if-exists :supersede)
+    (format stream +incbin-source-text+)))
 
 (defun system-c-name (system)
   "Replaces #\-, #\/, and #\. with #\_ in SYSTEM's name so as to produce
@@ -146,7 +151,7 @@ library and its header file."
   (let* ((c-name (library-c-name library))
          (bindings-filename (concatenate 'string c-name ".c"))
          (loadable-systems (remove-if-not #'system-loadable-from-fasl-p systems))
-         (source-filenames (append (list bindings-filename *incbin-filename* *fasl-loader-filename*)
+         (source-filenames (append (list bindings-filename +incbin-filename+ *fasl-loader-filename*)
                                    (mapcar #'system-fasl-bundle-filename loadable-systems))))
     (with-open-file (stream (uiop:merge-pathnames* "CMakeLists.txt" directory) :direction :output :if-exists :supersede)
       (format stream "cmake_minimum_required(VERSION ~A)~%" *cmake-minimum-required*)


### PR DESCRIPTION
This PR is a follow-on to #75 to fix a new error:

```
Unhandled UNBOUND-VARIABLE in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                        {70052A41F3}>:
  The variable SBCL-LIBRARIAN::*INCBIN-SOURCE-TEXT* is unbound.
```

This is happening because `(defparameter *incbin-source-text* ...)` is wrapped with only an `(eval-when (:compile-toplevel) ...)` to prevent the incbin source file from being read at any time other than compile-time. The problem is that it also makes the parameter unbound at load- or execution-time. This PR attempts to solve this by changing the `defparameter` to a `defconstant` and adding `:load-toplevel` and `:execute` to the eval-when. The idea is that the defconstant's initial value form should be evaluated once during compile-time.

EDIT: The defconstant's initial value form gets evaluated multiple times, causing a "can't reassign constant" failure. The workaround is to wrap the initial value form with an if expression that checks if the constant is already bound.