### PR TITLE
Put incbin source directly in a Lisp file

### DIFF
--- a/sbcl-librarian.asd
+++ b/sbcl-librarian.asd
@@ -24,6 +24,7 @@
                (:file "handles")
                (:file "loader")
                (:file "environment")
+               (:file "incbin")
                (:file "fasl-lib")
                (:file "diagnostics")
                ))

--- a/src/fasl-lib.lisp
+++ b/src/fasl-lib.lisp
@@ -1,20 +1,7 @@
 (in-package #:sbcl-librarian)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defconstant +incbin-filename+
-    (if (boundp '+incbin-filename+)
-        +incbin-filename+
-        "incbin.h")
-    "The name of the file containing the incbin source code.")
-
-  (defconstant +incbin-source-text+
-    (if (boundp '+incbin-source-text+)
-        +incbin-source-text+
-        (uiop:read-file-string
-         (asdf:system-relative-pathname "sbcl-librarian"
-                                        (uiop:merge-pathnames* +incbin-filename+ "src/"))))
-    "The full source code of incbin."))
-
+(defparameter *incbin-filename* "incbin.h"
+  "The name of the file containing the incbin source code.")
 
 (defparameter *fasl-loader-filename* "fasl_loader.c"
   "The name of the C source file that contains both embedded FASLs and a
@@ -60,8 +47,8 @@ skipping those for already-loaded systems."
 
 (defun create-incbin-source-file (directory)
   "Copy the incbin source code to DIRECTORY."
-  (with-open-file (stream (uiop:merge-pathnames* +incbin-filename+ directory) :direction :output :if-exists :supersede)
-    (format stream +incbin-source-text+)))
+  (with-open-file (stream (uiop:merge-pathnames* *incbin-filename* directory) :direction :output :if-exists :supersede)
+    (format stream *incbin-source-text*)))
 
 (defun system-c-name (system)
   "Replaces #\-, #\/, and #\. with #\_ in SYSTEM's name so as to produce
@@ -151,7 +138,7 @@ library and its header file."
   (let* ((c-name (library-c-name library))
          (bindings-filename (concatenate 'string c-name ".c"))
          (loadable-systems (remove-if-not #'system-loadable-from-fasl-p systems))
-         (source-filenames (append (list bindings-filename +incbin-filename+ *fasl-loader-filename*)
+         (source-filenames (append (list bindings-filename *incbin-filename* *fasl-loader-filename*)
                                    (mapcar #'system-fasl-bundle-filename loadable-systems))))
     (with-open-file (stream (uiop:merge-pathnames* "CMakeLists.txt" directory) :direction :output :if-exists :supersede)
       (format stream "cmake_minimum_required(VERSION ~A)~%" *cmake-minimum-required*)

--- a/src/incbin.lisp
+++ b/src/incbin.lisp
@@ -1,4 +1,7 @@
-/**
+(in-package :sbcl-librarian)
+
+(defparameter *incbin-source-text*
+  "/**
  * @file incbin.h
  * @author Dale Weiler
  * @brief Utility for including binary files
@@ -9,25 +12,25 @@
 #ifndef INCBIN_HDR
 #define INCBIN_HDR
 #include <limits.h>
-#if   defined(__AVX512BW__) || \
-      defined(__AVX512CD__) || \
-      defined(__AVX512DQ__) || \
-      defined(__AVX512ER__) || \
-      defined(__AVX512PF__) || \
-      defined(__AVX512VL__) || \
+#if   defined(__AVX512BW__) || \\
+      defined(__AVX512CD__) || \\
+      defined(__AVX512DQ__) || \\
+      defined(__AVX512ER__) || \\
+      defined(__AVX512PF__) || \\
+      defined(__AVX512VL__) || \\
       defined(__AVX512F__)
 # define INCBIN_ALIGNMENT_INDEX 6
-#elif defined(__AVX__)      || \
+#elif defined(__AVX__)      || \\
       defined(__AVX2__)
 # define INCBIN_ALIGNMENT_INDEX 5
-#elif defined(__SSE__)      || \
-      defined(__SSE2__)     || \
-      defined(__SSE3__)     || \
-      defined(__SSSE3__)    || \
-      defined(__SSE4_1__)   || \
-      defined(__SSE4_2__)   || \
-      defined(__neon__)     || \
-      defined(__ARM_NEON)   || \
+#elif defined(__SSE__)      || \\
+      defined(__SSE2__)     || \\
+      defined(__SSE3__)     || \\
+      defined(__SSSE3__)    || \\
+      defined(__SSE4_1__)   || \\
+      defined(__SSE4_2__)   || \\
+      defined(__neon__)     || \\
+      defined(__ARM_NEON)   || \\
       defined(__ALTIVEC__)
 # define INCBIN_ALIGNMENT_INDEX 4
 #elif ULONG_MAX != 0xffffffffu
@@ -46,25 +49,25 @@
 #define INCBIN_ALIGN_SHIFT_6 64
 
 /* Actual alignment value */
-#define INCBIN_ALIGNMENT \
-    INCBIN_CONCATENATE( \
-        INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _), \
+#define INCBIN_ALIGNMENT \\
+    INCBIN_CONCATENATE( \\
+        INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _), \\
         INCBIN_ALIGNMENT_INDEX)
 
 /* Stringize */
-#define INCBIN_STR(X) \
+#define INCBIN_STR(X) \\
     #X
-#define INCBIN_STRINGIZE(X) \
+#define INCBIN_STRINGIZE(X) \\
     INCBIN_STR(X)
 /* Concatenate */
-#define INCBIN_CAT(X, Y) \
+#define INCBIN_CAT(X, Y) \\
     X ## Y
-#define INCBIN_CONCATENATE(X, Y) \
+#define INCBIN_CONCATENATE(X, Y) \\
     INCBIN_CAT(X, Y)
 /* Deferred macro expansion */
-#define INCBIN_EVAL(X) \
+#define INCBIN_EVAL(X) \\
     X
-#define INCBIN_INVOKE(N, ...) \
+#define INCBIN_INVOKE(N, ...) \\
     INCBIN_EVAL(N(__VA_ARGS__))
 /* Variable argument count for overloading by arity */
 #define INCBIN_VA_ARG_COUNTER(_1, _2, _3, N, ...) N
@@ -73,48 +76,48 @@
 /* Green Hills uses a different directive for including binary data */
 #if defined(__ghs__)
 #  if (__ghs_asm == 2)
-#    define INCBIN_MACRO ".file"
-/* Or consider the ".myrawdata" entry in the ld file */
+#    define INCBIN_MACRO \".file\"
+/* Or consider the \".myrawdata\" entry in the ld file */
 #  else
-#    define INCBIN_MACRO "\tINCBIN"
+#    define INCBIN_MACRO \"\tINCBIN\"
 #  endif
 #else
-#  define INCBIN_MACRO ".incbin"
+#  define INCBIN_MACRO \".incbin\"
 #endif
 
 #ifndef _MSC_VER
-#  define INCBIN_ALIGN \
+#  define INCBIN_ALIGN \\
     __attribute__((aligned(INCBIN_ALIGNMENT)))
 #else
 #  define INCBIN_ALIGN __declspec(align(INCBIN_ALIGNMENT))
 #endif
 
-#if defined(__arm__) || /* GNU C and RealView */ \
-    defined(__arm) || /* Diab */ \
+#if defined(__arm__) || /* GNU C and RealView */ \\
+    defined(__arm) || /* Diab */ \\
     defined(_ARM) /* ImageCraft */
 #  define INCBIN_ARM
 #endif
 
 #ifdef __GNUC__
 /* Utilize .balign where supported */
-#  define INCBIN_ALIGN_HOST ".balign " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
-#  define INCBIN_ALIGN_BYTE ".balign 1\n"
+#  define INCBIN_ALIGN_HOST \".balign \" INCBIN_STRINGIZE(INCBIN_ALIGNMENT) \"\\n\"
+#  define INCBIN_ALIGN_BYTE \".balign 1\\n\"
 #elif defined(INCBIN_ARM)
 /*
  * On arm assemblers, the alignment value is calculated as (1 << n) where `n' is
  * the shift count. This is the value passed to `.align'
  */
-#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) "\n"
-#  define INCBIN_ALIGN_BYTE ".align 0\n"
+#  define INCBIN_ALIGN_HOST \".align \" INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) \"\\n\"
+#  define INCBIN_ALIGN_BYTE \".align 0\\n\"
 #else
 /* We assume other inline assembler's treat `.align' as `.balign' */
-#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
-#  define INCBIN_ALIGN_BYTE ".align 1\n"
+#  define INCBIN_ALIGN_HOST \".align \" INCBIN_STRINGIZE(INCBIN_ALIGNMENT) \"\\n\"
+#  define INCBIN_ALIGN_BYTE \".align 1\\n\"
 #endif
 
 /* INCBIN_CONST is used by incbin.c generated files */
 #if defined(__cplusplus)
-#  define INCBIN_EXTERNAL extern "C"
+#  define INCBIN_EXTERNAL extern \"C\"
 #  define INCBIN_CONST    extern const
 #else
 #  define INCBIN_EXTERNAL extern
@@ -130,9 +133,9 @@
  */
 #if !defined(INCBIN_OUTPUT_SECTION)
 #  if defined(__APPLE__)
-#    define INCBIN_OUTPUT_SECTION ".const_data"
+#    define INCBIN_OUTPUT_SECTION \".const_data\"
 #  else
-#    define INCBIN_OUTPUT_SECTION ".rodata"
+#    define INCBIN_OUTPUT_SECTION \".rodata\"
 #  endif
 #endif
 
@@ -161,41 +164,41 @@
 #endif
 
 #if defined(__APPLE__)
-#  include "TargetConditionals.h"
+#  include \"TargetConditionals.h\"
 #  if defined(TARGET_OS_IPHONE) && !defined(INCBIN_SILENCE_BITCODE_WARNING)
-#    warning "incbin is incompatible with bitcode. Using the library will break upload to App Store if you have bitcode enabled. Add `#define INCBIN_SILENCE_BITCODE_WARNING` before including this header to silence this warning."
+#    warning \"incbin is incompatible with bitcode. Using the library will break upload to App Store if you have bitcode enabled. Add `#define INCBIN_SILENCE_BITCODE_WARNING` before including this header to silence this warning.\"
 #  endif
 /* The directives are different for Apple branded compilers */
-#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
-#  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
-#  define INCBIN_INT             ".long "
-#  define INCBIN_MANGLE          "_"
-#  define INCBIN_BYTE            ".byte "
+#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION \"\\n\"
+#  define INCBIN_GLOBAL(NAME)    \".globl \" INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME \"\\n\"
+#  define INCBIN_INT             \".long \"
+#  define INCBIN_MANGLE          \"_\"
+#  define INCBIN_BYTE            \".byte \"
 #  define INCBIN_TYPE(...)
 #else
-#  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
-#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  define INCBIN_SECTION         \".section \" INCBIN_OUTPUT_SECTION \"\\n\"
+#  define INCBIN_GLOBAL(NAME)    \".global \" INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME \"\\n\"
 #  if defined(__ghs__)
-#    define INCBIN_INT           ".word "
+#    define INCBIN_INT           \".word \"
 #  else
-#    define INCBIN_INT           ".int "
+#    define INCBIN_INT           \".int \"
 #  endif
 #  if defined(__USER_LABEL_PREFIX__)
 #    define INCBIN_MANGLE        INCBIN_STRINGIZE(__USER_LABEL_PREFIX__)
 #  else
-#    define INCBIN_MANGLE        ""
+#    define INCBIN_MANGLE        \"\"
 #  endif
 #  if defined(INCBIN_ARM)
 /* On arm assemblers, `@' is used as a line comment token */
-#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
+#    define INCBIN_TYPE(NAME)    \".type \" INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME \", %object\\n\"
 #  elif defined(__MINGW32__) || defined(__MINGW64__)
 /* Mingw doesn't support this directive either */
 #    define INCBIN_TYPE(NAME)
 #  else
 /* It's safe to use `@' on other architectures */
-#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", @object\n"
+#    define INCBIN_TYPE(NAME)    \".type \" INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME \", @object\\n\"
 #  endif
-#  define INCBIN_BYTE            ".byte "
+#  define INCBIN_BYTE            \".byte \"
 #endif
 
 /* List of style types used for symbol names */
@@ -205,12 +208,12 @@
 /**
  * @brief Specify the prefix to use for symbol names.
  *
- * @note By default this is "g".
+ * @note By default this is \"g\".
  *
  * @code
  * #define INCBIN_PREFIX incbin
- * #include "incbin.h"
- * INCBIN(Foo, "foo.txt");
+ * #include \"incbin.h\"
+ * INCBIN(Foo, \"foo.txt\");
  *
  * // Now you have the following symbols instead:
  * // const unsigned char incbinFoo<data>[];
@@ -226,15 +229,15 @@
  * @brief Specify the style used for symbol names.
  *
  * Possible options are
- * - INCBIN_STYLE_CAMEL "CamelCase"
- * - INCBIN_STYLE_SNAKE "snake_case"
+ * - INCBIN_STYLE_CAMEL \"CamelCase\"
+ * - INCBIN_STYLE_SNAKE \"snake_case\"
  *
  * @note By default this is INCBIN_STYLE_CAMEL
  *
  * @code
  * #define INCBIN_STYLE INCBIN_STYLE_SNAKE
- * #include "incbin.h"
- * INCBIN(foo, "foo.txt");
+ * #include \"incbin.h\"
+ * INCBIN(foo, \"foo.txt\");
  *
  * // Now you have the following symbols:
  * // const unsigned char <prefix>foo_data[];
@@ -255,34 +258,34 @@
 #define INCBIN_STYLE_1_SIZE _size
 
 /* Style lookup: returning identifier */
-#define INCBIN_STYLE_IDENT(TYPE) \
-    INCBIN_CONCATENATE( \
-        INCBIN_STYLE_, \
-        INCBIN_CONCATENATE( \
-            INCBIN_EVAL(INCBIN_STYLE), \
+#define INCBIN_STYLE_IDENT(TYPE) \\
+    INCBIN_CONCATENATE( \\
+        INCBIN_STYLE_, \\
+        INCBIN_CONCATENATE( \\
+            INCBIN_EVAL(INCBIN_STYLE), \\
             INCBIN_CONCATENATE(_, TYPE)))
 
 /* Style lookup: returning string literal */
-#define INCBIN_STYLE_STRING(TYPE) \
-    INCBIN_STRINGIZE( \
-        INCBIN_STYLE_IDENT(TYPE)) \
+#define INCBIN_STYLE_STRING(TYPE) \\
+    INCBIN_STRINGIZE( \\
+        INCBIN_STYLE_IDENT(TYPE)) \\
 
 /* Generate the global labels by indirectly invoking the macro with our style
  * type and concatenating the name against them. */
-#define INCBIN_GLOBAL_LABELS(NAME, TYPE) \
-    INCBIN_INVOKE( \
-        INCBIN_GLOBAL, \
-        INCBIN_CONCATENATE( \
-            NAME, \
-            INCBIN_INVOKE( \
-                INCBIN_STYLE_IDENT, \
-                TYPE))) \
-    INCBIN_INVOKE( \
-        INCBIN_TYPE, \
-        INCBIN_CONCATENATE( \
-            NAME, \
-            INCBIN_INVOKE( \
-                INCBIN_STYLE_IDENT, \
+#define INCBIN_GLOBAL_LABELS(NAME, TYPE) \\
+    INCBIN_INVOKE( \\
+        INCBIN_GLOBAL, \\
+        INCBIN_CONCATENATE( \\
+            NAME, \\
+            INCBIN_INVOKE( \\
+                INCBIN_STYLE_IDENT, \\
+                TYPE))) \\
+    INCBIN_INVOKE( \\
+        INCBIN_TYPE, \\
+        INCBIN_CONCATENATE( \\
+            NAME, \\
+            INCBIN_INVOKE( \\
+                INCBIN_STYLE_IDENT, \\
                 TYPE)))
 
 /**
@@ -292,7 +295,7 @@
  * another translation unit.
  *
  * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
- * "Data", as well as "End" and "Size" after. An example is provided below.
+ * \"Data\", as well as \"End\" and \"Size\" after. An example is provided below.
  *
  * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
  * @param NAME The name given for the binary data
@@ -316,22 +319,22 @@
  * // extern const unsigned int <prefix>Foo<size>;
  * @endcode
  */
-#define INCBIN_EXTERN(...) \
+#define INCBIN_EXTERN(...) \\
     INCBIN_CONCATENATE(INCBIN_EXTERN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
-#define INCBIN_EXTERN_1(NAME, ...) \
+#define INCBIN_EXTERN_1(NAME, ...) \\
     INCBIN_EXTERN_2(unsigned char, NAME)
-#define INCBIN_EXTERN_2(TYPE, NAME) \
-    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE \
-        INCBIN_CONCATENATE( \
-            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
-            INCBIN_STYLE_IDENT(DATA))[]; \
-    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE *const \
-    INCBIN_CONCATENATE( \
-        INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
-        INCBIN_STYLE_IDENT(END)); \
-    INCBIN_EXTERNAL const unsigned int \
-        INCBIN_CONCATENATE( \
-            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+#define INCBIN_EXTERN_2(TYPE, NAME) \\
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE \\
+        INCBIN_CONCATENATE( \\
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \\
+            INCBIN_STYLE_IDENT(DATA))[]; \\
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE *const \\
+    INCBIN_CONCATENATE( \\
+        INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \\
+        INCBIN_STYLE_IDENT(END)); \\
+    INCBIN_EXTERNAL const unsigned int \\
+        INCBIN_CONCATENATE( \\
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \\
             INCBIN_STYLE_IDENT(SIZE))
 
 /**
@@ -341,7 +344,7 @@
  * another translation unit.
  *
  * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
- * "Data", as well as "End" and "Size" after. An example is provided below.
+ * \"Data\", as well as \"End\" and \"Size\" after. An example is provided below.
  *
  * @param NAME The name given for the textual data
  *
@@ -354,7 +357,7 @@
  * // extern const unsigned int <prefix>Foo<size>;
  * @endcode
  */
-#define INCTXT_EXTERN(NAME) \
+#define INCTXT_EXTERN(NAME) \\
     INCBIN_EXTERN_2(char, NAME)
 
 /**
@@ -364,14 +367,14 @@
  * for objects that encode the data and size respectively.
  *
  * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
- * "Data", as well as "End" and "Size" after. An example is provided below.
+ * \"Data\", as well as \"End\" and \"Size\" after. An example is provided below.
  *
  * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
  * @param NAME The name to associate with this binary data (as an identifier.)
  * @param FILENAME The file to include (as a string literal.)
  *
  * @code
- * INCBIN(Icon, "icon.png");
+ * INCBIN(Icon, \"icon.png\");
  *
  * // Now you have the following symbols:
  * // const unsigned char <prefix>Icon<data>[];
@@ -382,7 +385,7 @@
  * You may specify a custom optional data type as well as the first argument.
  * These macros are specialized by arity.
  * @code
- * INCBIN(custom_type, Icon, "icon.png");
+ * INCBIN(custom_type, Icon, \"icon.png\");
  *
  * // Now you have the following symbols:
  * // const custom_type <prefix>Icon<data>[];
@@ -397,40 +400,40 @@
  * please @see INCBIN_EXTERN.
  */
 #ifdef _MSC_VER
-#  define INCBIN(NAME, FILENAME) \
+#  define INCBIN(NAME, FILENAME) \\
       INCBIN_EXTERN(NAME)
 #else
-#  define INCBIN(...) \
+#  define INCBIN(...) \\
      INCBIN_CONCATENATE(INCBIN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
 #  if defined(__GNUC__)
-#    define INCBIN_1(...) _Pragma("GCC error \"Single argument INCBIN not allowed\"")
+#    define INCBIN_1(...) _Pragma(\"GCC error \"Single argument INCBIN not allowed\"\")
 #  elif defined(__clang__)
-#    define INCBIN_1(...) _Pragma("clang error \"Single argument INCBIN not allowed\"")
+#    define INCBIN_1(...) _Pragma(\"clang error \"Single argument INCBIN not allowed\"\")
 #  else
 #    define INCBIN_1(...) /* Cannot do anything here */
 #  endif
-#  define INCBIN_2(NAME, FILENAME) \
+#  define INCBIN_2(NAME, FILENAME) \\
       INCBIN_3(unsigned char, NAME, FILENAME)
 #  define INCBIN_3(TYPE, NAME, FILENAME) INCBIN_COMMON(TYPE, NAME, FILENAME, /* No terminator for binary data */)
-#  define INCBIN_COMMON(TYPE, NAME, FILENAME, TERMINATOR) \
-    __asm__(INCBIN_SECTION \
-            INCBIN_GLOBAL_LABELS(NAME, DATA) \
-            INCBIN_ALIGN_HOST \
-            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) ":\n" \
-            INCBIN_MACRO " \"" FILENAME "\"\n" \
-                TERMINATOR \
-            INCBIN_GLOBAL_LABELS(NAME, END) \
-            INCBIN_ALIGN_BYTE \
-            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
-                INCBIN_BYTE "1\n" \
-            INCBIN_GLOBAL_LABELS(NAME, SIZE) \
-            INCBIN_ALIGN_HOST \
-            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" \
-                INCBIN_INT INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) " - " \
-                           INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) "\n" \
-            INCBIN_ALIGN_HOST \
-            ".text\n" \
-    ); \
+#  define INCBIN_COMMON(TYPE, NAME, FILENAME, TERMINATOR) \\
+    __asm__(INCBIN_SECTION \\
+            INCBIN_GLOBAL_LABELS(NAME, DATA) \\
+            INCBIN_ALIGN_HOST \\
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) \":\\n\" \\
+            INCBIN_MACRO \" \\\"\" FILENAME \"\\\"\\n\" \\
+                TERMINATOR \\
+            INCBIN_GLOBAL_LABELS(NAME, END) \\
+            INCBIN_ALIGN_BYTE \\
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) \":\\n\" \\
+                INCBIN_BYTE \"1\\n\" \\
+            INCBIN_GLOBAL_LABELS(NAME, SIZE) \\
+            INCBIN_ALIGN_HOST \\
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) \":\\n\" \\
+                INCBIN_INT INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) \" - \" \\
+                           INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) \"\\n\" \\
+            INCBIN_ALIGN_HOST \\
+            \".text\\n\" \\
+    ); \\
     INCBIN_EXTERN(TYPE, NAME)
 #endif
 
@@ -445,13 +448,13 @@
  * symbols for objects that encode the data and size respectively.
  *
  * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
- * "Data", as well as "End" and "Size" after. An example is provided below.
+ * \"Data\", as well as \"End\" and \"Size\" after. An example is provided below.
  *
  * @param NAME The name to associate with this binary data (as an identifier.)
  * @param FILENAME The file to include (as a string literal.)
  *
  * @code
- * INCTXT(Readme, "readme.txt");
+ * INCTXT(Readme, \"readme.txt\");
  *
  * // Now you have the following symbols:
  * // const char <prefix>Readme<data>[];
@@ -466,11 +469,11 @@
  * please @see INCBIN_EXTERN.
  */
 #if defined(_MSC_VER)
-#  define INCTXT(NAME, FILENAME) \
+#  define INCTXT(NAME, FILENAME) \\
      INCBIN_EXTERN(NAME)
 #else
-#  define INCTXT(NAME, FILENAME) \
-     INCBIN_COMMON(char, NAME, FILENAME, INCBIN_BYTE "0\n")
+#  define INCTXT(NAME, FILENAME) \\
+     INCBIN_COMMON(char, NAME, FILENAME, INCBIN_BYTE \"0\\n\")
 #endif
 
-#endif
+#endif")


### PR DESCRIPTION
This bypasses the trouble of trying to read `incbin.h` into a parameter/constant at the right time. Double quotes, newlines, tabs, and backslashes had to be escaped.