### PR TITLE
Check if runtime is initialized before calling into Lisp

### DIFF
--- a/lib/entry_point.c
+++ b/lib/entry_point.c
@@ -31,6 +31,7 @@ extern void set_lossage_handler(void (*handler)(void));
 extern int initialize_lisp(int argc, const char *argv[], char *envp[]);
 
 int fatal_sbcl_error_occurred = 0;
+int initialized = 0;
 
 static void return_from_lisp(void)
 {
@@ -66,6 +67,7 @@ static void do_initialize_lisp(const char *libsbcl_librarian_path)
     dlopen(libsbcl_librarian_path, RTLD_NOW | RTLD_GLOBAL);
 #endif
     initialize_lisp(sizeof(init_args) / sizeof(init_args[0]), init_args, NULL);
+    initialized = 1;
     set_lossage_handler(return_from_lisp);
 }
 

--- a/lib/python/src/sbcl_librarian/errors.py
+++ b/lib/python/src/sbcl_librarian/errors.py
@@ -4,4 +4,5 @@ class lisp_err_t(int):
         1: "LISP_ERR_FAILURE",
         2: "LISP_ERR_BUG",
         3: "LISP_ERR_FATAL",
+        4: "LISP_ERR_NOT_INITIALIZED",
     }

--- a/lib/python/src/sbcl_librarian/wrapper.py
+++ b/lib/python/src/sbcl_librarian/wrapper.py
@@ -28,6 +28,10 @@ class LispFatal(Exception):
     pass
 
 
+class LispNotInitialized(Exception):
+    pass
+
+
 LispHandle = ctypes.c_void_p
 
 
@@ -111,6 +115,10 @@ def lift_fn(name: str, fn: Callable[..., Any]) -> Callable[..., Any]:
             if result == 3:
                 raise LispFatal(
                     "SBCL crashed with a fatal, non-recoverable error. All subsequent calls into Lisp will raise the same exception."
+                )
+            elif result == 4:
+                raise LispNotInitialized(
+                    "The SBCL runtime must be initialized before calling into Lisp."
                 )
             msg = ctypes.c_char_p()
             sbcl_librarian.raw.get_error_message(ctypes.byref(msg))

--- a/lib/sbcl_librarian_err.h
+++ b/lib/sbcl_librarian_err.h
@@ -73,11 +73,13 @@ extern __thread LIBSBCL_LIBRARIAN_ERR_API jmp_buf fatal_lisp_error_handler;
 #endif
 
 extern int LIBSBCL_LIBRARIAN_ERR_API fatal_sbcl_error_occurred;
+extern int LIBSBCL_LIBRARIAN_ERR_API initialized;
 extern void ldb_monitor(void);
 
 typedef enum {
     LISP_ERR_SUCCESS = 0,
     LISP_ERR_FAILURE = 1,
     LISP_ERR_BUG = 2,
-    LISP_ERR_FATAL = 3
+    LISP_ERR_FATAL = 3,
+    LISP_ERR_NOT_INITIALIZED = 4
 } lisp_err_t;

--- a/src/function.lisp
+++ b/src/function.lisp
@@ -84,7 +84,9 @@ if (!setjmp(fatal_lisp_error_handler)) {
                                           (list "result"))))))
         (format nil "~a {~%~a~%}~%"
                 header
-                (format nil "    if (!fatal_sbcl_error_occurred && !setjmp(fatal_lisp_error_handler~a)) {
+                (format nil "    if (!initialized) {
+        return LISP_ERR_NOT_INITIALIZED;
+    } else if (!fatal_sbcl_error_occurred && !setjmp(fatal_lisp_error_handler~a)) {
         ~a
     } else {
         ~a


### PR DESCRIPTION
This PR exposes the `initialized` variable in `sbcl_librarian_err.h` and checks if it has been set before calling into Lisp.