### PR TITLE
Move per-call signal handling from Python to C

### DIFF
--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -119,6 +119,7 @@
                             :if-exists :supersede)
       (format stream "#define ~A~%~%" build-flag)
       (format stream "#include ~s~%~%" header-name)
+      (format stream "#include <signal.h>~%~%")
       (dolist (api (library-apis library))
         (write-api-to-source api linkage stream))
       (unless omit-init-function

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -119,7 +119,8 @@
                             :if-exists :supersede)
       (format stream "#define ~A~%~%" build-flag)
       (format stream "#include ~s~%~%" header-name)
-      (format stream "#include <signal.h>~%~%")
+      (format stream "#include <signal.h>~%")
+      (format stream "#ifndef _WIN32~%#include <pthread.h>~%#endif~%~%")
       (dolist (api (library-apis library))
         (write-api-to-source api linkage stream))
       (unless omit-init-function

--- a/src/function.lisp
+++ b/src/function.lisp
@@ -88,7 +88,22 @@ if (!setjmp(fatal_lisp_error_handler)) {
         return LISP_ERR_NOT_INITIALIZED;
     } else if (!fatal_sbcl_error_occurred && !setjmp(fatal_lisp_error_handler~a)) {
         void *sigint_handler = signal(SIGINT, 0);
+#ifdef __linux__
+        sigset_t mask1;
+        sigemptyset(&mask1);
+        sigaddset(&mask1, SIGSEGV);
+        sigaddset(&mask1, SIGTRAP);
+
+        pthread_sigmask(SIG_UNBLOCK, &mask1, 0);
+#endif
         ~a
+#ifdef __APPLE__
+        sigset_t mask2;
+        sigemptyset(&mask2);
+        sigaddset(&mask2, SIGINT);
+
+        pthread_sigmask(SIG_UNBLOCK, &mask2, 0);
+#endif
         signal(SIGINT, sigint_handler);
     } else {
         ~a

--- a/src/function.lisp
+++ b/src/function.lisp
@@ -87,7 +87,9 @@ if (!setjmp(fatal_lisp_error_handler)) {
                 (format nil "    if (!initialized) {
         return LISP_ERR_NOT_INITIALIZED;
     } else if (!fatal_sbcl_error_occurred && !setjmp(fatal_lisp_error_handler~a)) {
+        void *sigint_handler = signal(SIGINT, 0);
         ~a
+        signal(SIGINT, sigint_handler);
     } else {
         ~a
     }"


### PR DESCRIPTION
This PR moves the signal handling logic performed around Lisp calls from Python to C. The rationale for doing this is that only the main Python interpreter thread can set signal handlers[^1], preventing non-main Python threads from safely calling into Lisp.

[^1]: https://docs.python.org/3/library/signal.html#signals-and-threads