### PR TITLE
Don't require SB-SPROF on Win32

### DIFF
--- a/src/diagnostics.lisp
+++ b/src/diagnostics.lisp
@@ -31,10 +31,16 @@
   (values))
 
 (defun start-profiling (args)
-  (apply #'sb-sprof:start-profiling (read-from-string args)))
+  #-win32
+  (apply #'sb-sprof:start-profiling (read-from-string args))
+  #+win32
+  (format t "SB-SPROF is not supported on Windows."))
 
 (defun profiler-report (args)
-  (apply #'sb-sprof:report (read-from-string args)))
+  #-win32
+  (apply #'sb-sprof:report (read-from-string args))
+  #+win32
+  (format t "SB-SPROF is not supported on Windows."))
 
 (define-api diagnostics (:function-prefix "")
   (:function

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,4 +1,5 @@
 ;;;; package.lisp
+#-win32
 (require "sb-sprof")
 
 (defpackage #:sbcl-librarian


### PR DESCRIPTION
SB-SPROF isn't supported on Windows, so don't require it.