### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/function.lisp
+++ b/src/function.lisp
@@ -73,8 +73,8 @@ if (!setjmp(fatal_lisp_error_handler)) {
         (canonical-signature name result-type typed-lambda-list
                              :function-prefix function-prefix
                              :error-map error-map)
-      (declare (ignore return-type))
-      (let ((call-statement (format nil "return ~a(~{~a~^, ~});"
+      (let ((call-statement (format nil "~a result_code = ~a(~{~a~^, ~});"
+                                    (c-type return-type)
                                     (concatenate 'string "_" (coerce-to-c-name callable-name))
                                     (append
                                      (mapcar (lambda (item)
@@ -105,6 +105,7 @@ if (!setjmp(fatal_lisp_error_handler)) {
         pthread_sigmask(SIG_UNBLOCK, &mask2, 0);
 #endif
         signal(SIGINT, sigint_handler);
+        return result_code;
     } else {
         ~a
     }"


### PR DESCRIPTION
This PR fixes two things:

1. Moves the return statement in the function stubs after the signal handling logic.
2. Redirects only the system bundle FASLs to the build directory instead of all FASLs produced during the build. Redirecting all the FASLs causes conflicts between systems with common source file names.