### PR TITLE
Add option to EVAL an expression before loading FASLs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,6 +67,6 @@ jobs:
         popd
         popd
         gcc -Wall -o example example.c -lcalc -lsbcl_librarian -lsbcl
-        echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" ./example | tr -d '\n' | grep "> 3> "
+        echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" ./example | tr -d '\n' | grep "hello from preload> 3> "
         echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./example.py | tr -d '\n' | grep "> 3> "
         LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./exhaust_heap.py | grep "returned to Python after heap exhaustion (attempt 1)"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -70,6 +70,6 @@ jobs:
         popd
         popd
         gcc -Wall -o example example.c -lcalc -lsbcl_librarian
-        echo "(+ 1 2)" | ./example | tr -d '\n' | grep "> 3> "
+        echo "(+ 1 2)" | ./example | tr -d '\n' | grep "hello from preload> 3> "
         echo "(+ 1 2)" | python ./example.py | tr -d '\n' | grep "> 3> "
         python ./exhaust_heap.py | grep "returned to Python after heap exhaustion (attempt 1)"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,5 +92,6 @@ jobs:
         popd
         D:\a\_temp\setup-msys2\msys2.CMD -c "gcc -Wall -o example example.c -lcalc -lsbcl_librarian"
         if ((echo '(+ 1 2)' | .\example.exe) -match "3") { exit 0 } else { exit 1 }
+        if ((echo '(+ 1 2)' | .\example.exe) -match "hello from preload") { exit 0 } else { exit 1 }
         if ((echo '(+ 1 2)' | python example.py) -match "3") { exit 0 } else { exit 1 }
         if ((python exhaust_heap.py) -match "attempt 1") { exit 0 } else { exit 1 }

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -5,5 +5,6 @@
 
 (in-package #:sbcl-librarian/example/libcalc)
 
-(sbcl-librarian:create-fasl-library-cmake-project "libcalc" calc "./libcalc/")
+(sbcl-librarian:create-fasl-library-cmake-project "libcalc" calc "./libcalc/"
+                                                  :preload-eval-expr "(format t \"hello from preload~%\")")
 (sbcl-librarian:build-python-bindings calc "." :omit-init-call t)

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -37,9 +37,16 @@ passing no arguments and throwing away the return value."
     (funcall (symbol-function symbol)))
   (values))
 
+(defun eval-string (expr)
+  "Evaluates the expression contained in EXPR for its side-effects,
+throwing away its result."
+  (eval (read-from-string expr))
+  (values))
+
 (define-api environment (:function-prefix "")
   (:function
    (("lisp_enable_debugger" enable-debugger) :void ())
    (("lisp_disable_debugger" disable-debugger) :void ())
    (("lisp_gc" gc) :void ())
-   (("lisp_funcall0_by_name" funcall0-by-name) :void ((name :string) (package-name :string)))))
+   (("lisp_funcall0_by_name" funcall0-by-name) :void ((name :string) (package-name :string)))
+   (("lisp_eval_string" eval-string) :void ((expr :string)))))


### PR DESCRIPTION
This PR adds an option to EVAL an expression before loading the FASLs contained in a shared library by calling a new `lisp_eval_string` function exported by sbcl_librarian.dll.