### PR TITLE
Don't resolve libpath on Linux

### DIFF
--- a/lib/generate-bindings.lisp
+++ b/lib/generate-bindings.lisp
@@ -82,7 +82,7 @@
     #+(and win32 github-ci)
     (format stream "    libpath = Path(os.path.join(os.environ['CONDA_PREFIX'], 'bin', 'sbcl_librarian.dll')).resolve()~%")
     #-(and win32 github-ci)
-    (format stream "    libpath = Path(find_~a()).resolve()~%" name)
+    (format stream "    libpath = Path(find_~a())~a~%" name #-linux ".resolve()" #+linux "")
     (format stream "except Exception as e:~%")
     (format stream "    raise Exception('Unable to locate ~a') from e~%~%" name)
 


### PR DESCRIPTION
`resolve`ing the `Path` object containing the binding library's name seems to add the home directory on Linux, causing the `CDLL` call to fail. This MR removes the `resolve` call on Linux.