### PR TITLE
Allow environment variables in initialize-lisp-args

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,6 +43,7 @@ jobs:
       env:
         LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
         LD_LIBRARY_PATH: ${{ github.workspace }}/../sbcl/src/runtime
+        HEAP_SIZE: 1024
       run: |
         conda install -y conda-build
         conda build recipe --output-folder conda-bld
@@ -52,11 +53,11 @@ jobs:
         echo "LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib:$CONDA_PREFIX/lib64" >> "$GITHUB_ENV"
         echo "LD_LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib:$CONDA_PREFIX/lib64" >> "$GITHUB_ENV"
         echo "C_INCLUDE_PATH=$CONDA_PREFIX/include" >> "$GITHUB_ENV"
+        echo "HEAP_SIZE=1024" >> "$GITHUB_ENV"
     - name: build and run example
       working-directory: examples/libcalc
       env:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
-        HEAP_SIZE: 1024
       run: |
         $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         pushd libcalc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,6 +60,7 @@ jobs:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
       run: |
         $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
+        LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./check_dynamic_space_size.py
         pushd libcalc
         mkdir build
         pushd build
@@ -72,5 +73,5 @@ jobs:
         echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" ./example | tr -d '\n' | grep "hello from preload> 3> "
         echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./example.py | tr -d '\n' | grep "> 3> "
         echo $HEAP_SIZE
-        LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./check_dynamic_space_size.py
+        
         LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./exhaust_heap.py | grep "returned to Python after heap exhaustion (attempt 1)"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,6 +56,7 @@ jobs:
       working-directory: examples/libcalc
       env:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
+        HEAP_SIZE: 1024
       run: |
         $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         pushd libcalc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,7 @@ jobs:
         echo "LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib:$CONDA_PREFIX/lib64" >> "$GITHUB_ENV"
         echo "LD_LIBRARY_PATH=$LIBSBCL_PATH:$CONDA_PREFIX/lib:$CONDA_PREFIX/lib64" >> "$GITHUB_ENV"
         echo "C_INCLUDE_PATH=$CONDA_PREFIX/include" >> "$GITHUB_ENV"
-        echo "HEAP_SIZE=1024" >> "$GITHUB_ENV"
+        echo "HEAP_SIZE=2048" >> "$GITHUB_ENV"
     - name: build and run example
       working-directory: examples/libcalc
       env:
@@ -71,4 +71,6 @@ jobs:
         gcc -Wall -o example example.c -lcalc -lsbcl_librarian -lsbcl
         echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" ./example | tr -d '\n' | grep "hello from preload> 3> "
         echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./example.py | tr -d '\n' | grep "> 3> "
+        echo $HEAP_SIZE
+        LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./check_dynamic_space_size.py
         LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./exhaust_heap.py | grep "returned to Python after heap exhaustion (attempt 1)"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -59,6 +59,7 @@ jobs:
       working-directory: examples/libcalc
       env:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
+        HEAP_SIZE: 1024
       run: |
         $SBCL_SRC/run-sbcl.sh --load script.lisp --quit
         pushd libcalc

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,6 +77,7 @@ jobs:
       env:
         CL_SOURCE_REGISTRY: "${{ github.workspace }}//"
         MSYS_PATH_TYPE: inherit
+        HEAP_SIZE: 1024
       shell: pwsh
       run: |
         $env:MINGW64_PATH="D:\a\_temp\msys64\mingw64\bin"

--- a/examples/libcalc/bindings.lisp
+++ b/examples/libcalc/bindings.lisp
@@ -9,6 +9,9 @@
     (let ((test '()))
       (loop (push 1 test)))))
 
+(defun print-dynamic-space-size ()
+  (format *standard-output* "~%~%~% HEAP SIZE:~%~d~%~%~%" (sb-ext:dynamic-space-size)))
+
 (sbcl-librarian:define-api libcalc-api (:function-prefix "calc_")
   (:literal "/* types */")
   (:type expr-type)
@@ -25,7 +28,8 @@
    (parse expr-type ((source :string)))
    (expression-to-string :string ((expr expr-type)))
    (remove-zeros expr-type ((expr expr-type)))
-   (exhaust-heap :void ())))
+   (exhaust-heap :void ())
+   (print-dynamic-space-size :void ())))
 
 (sbcl-librarian:define-aggregate-library calc (:function-linkage "CALC_API")
   libcalc-api)

--- a/examples/libcalc/check_dynamic_space_size.py
+++ b/examples/libcalc/check_dynamic_space_size.py
@@ -1,0 +1,17 @@
+import os
+import platform
+
+# Python has trouble finding some dependent DLLs in the Windows CI
+# environment, so we register their directories directly
+if platform.system() == 'Windows':
+    os.add_dll_directory(os.environ.get('LIBSBCL_PATH'))
+    os.add_dll_directory(os.environ.get('MINGW64_PATH'))
+
+import sbcl_librarian.wrapper
+import calc as libcalc
+import sys
+
+
+if __name__ == '__main__':
+    # Attempting to call into Lisp again should throw the same exception
+    libcalc.calc_print_dynamic_space_size()

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -10,7 +10,5 @@
 
 (sbcl-librarian:build-python-bindings calc "." :omit-init-call t)
 
-(sbcl-librarian:build-bindings calc "." :initialize-lisp-args (list "--dynamic-space-size"
-                                                                    (if (uiop:getenv HEAP_SIZE)
-                                                                        (:env "HEAP_SIZE")
-                                                                        "2048")))
+(sbcl-librarian:build-bindings calc "." :initialize-lisp-args '("--dynamic-space-size"
+                                                                (:env "HEAP_SIZE")))

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -7,4 +7,10 @@
 
 (sbcl-librarian:create-fasl-library-cmake-project "libcalc" calc "./libcalc/"
                                                   :preload-eval-expr "(format t \"hello from preload~%\")")
+
 (sbcl-librarian:build-python-bindings calc "." :omit-init-call t)
+
+(sbcl-librarian:build-bindings calc "." :initialize-lisp-args (list "--dynamic-space-size"
+                                                                    (if (uiop:getenv HEAP_SIZE)
+                                                                        (:env "HEAP_SIZE")
+                                                                        "2048")))

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -5,10 +5,11 @@
 
 (in-package #:sbcl-librarian/example/libcalc)
 
-(sbcl-librarian:create-fasl-library-cmake-project "libcalc" calc "./libcalc/"
+#+ig(sbcl-librarian:create-fasl-library-cmake-project "libcalc" calc "./libcalc/"
                                                   :preload-eval-expr "(format t \"hello from preload~%\")")
 
 (sbcl-librarian:build-python-bindings calc "." :omit-init-call t)
 
 (sbcl-librarian:build-bindings calc "." :initialize-lisp-args '("--dynamic-space-size"
-                                                                (:env "HEAP_SIZE")))
+                                                                "4098" ;(:env "HEAP_SIZE")
+                                                                ))

--- a/examples/libcalc/script.lisp
+++ b/examples/libcalc/script.lisp
@@ -5,11 +5,11 @@
 
 (in-package #:sbcl-librarian/example/libcalc)
 
-#+ig(sbcl-librarian:create-fasl-library-cmake-project "libcalc" calc "./libcalc/"
-                                                  :preload-eval-expr "(format t \"hello from preload~%\")")
+(sbcl-librarian:create-fasl-library-cmake-project "libcalc" calc "./libcalc/"
+                                                  :preload-eval-expr "(format t \"hello from preload~%\")"
+                                                  ;:initialize-lisp-args
+                                                  #+ig
+                                                  ("--dynamic-space-size"
+                                                   (:env "HEAP_SIZE")))
 
 (sbcl-librarian:build-python-bindings calc "." :omit-init-call t)
-
-(sbcl-librarian:build-bindings calc "." :initialize-lisp-args '("--dynamic-space-size"
-                                                                "4098" ;(:env "HEAP_SIZE")
-                                                                ))

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -73,9 +73,11 @@
 
 (defun error-if-not-alphanumeric (str)
   (unless (every #'(lambda (char)
-		     (or (alpha-char-p char)
-			 (digit-char-p char)))
-		 str)
+                     (or (alpha-char-p char)
+                         (digit-char-p char)
+                         (char= char #\_)
+                         (char= char #\-)))
+                 str)
     (error "Lisp init arg must be alphanumeric: ~a" str)))
 
 (defun format-init-args (initialize-lisp-args)
@@ -83,13 +85,13 @@
   (loop :for arg :in initialize-lisp-args
         :collect (etypecase arg
                    (cons
-		    (cond ((eq (first arg) ':env)
-			   (error-if-not-alphanumeric (second arg))
-			   (format nil "getenv(\"~a\")" (second arg)))
-			  (t
-			   (error "Invalid lisp arg: ~a" arg))))
+                    (cond ((eq (first arg) ':env)
+                           (error-if-not-alphanumeric (second arg))
+                           (format nil "getenv(\"~a\")" (second arg)))
+                          (t
+                           (error "Invalid lisp arg: ~a" arg))))
                    (string
-		    (error-if-not-alphanumeric arg)
+                    (error-if-not-alphanumeric arg)
                     (format nil "~s" arg)))))
 
 (defun write-init-function (name linkage stream &optional (initialize-lisp-args nil))

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -71,12 +71,14 @@
                                             :function-prefix (api-function-prefix api)
                                             :error-map (api-error-map api))))))))))
 
-(defun error-if-not-alphanumeric (str)
-  (unless (every #'(lambda (char)
-                     (or (alpha-char-p char)
+(defun alphanumeric-p (char)
+  (or (alpha-char-p char)
                          (digit-char-p char)
                          (char= char #\_)
                          (char= char #\-)))
+
+(defun error-if-not-alphanumeric (str)
+  (unless (every #'alphanumeric-p
                  str)
     (error "Lisp init arg must be alphanumeric: ~a" str)))
 
@@ -84,15 +86,15 @@
   "This formats sbcl init args in generated c code as either strings or environment variables."
   (loop :for arg :in initialize-lisp-args
         :collect (etypecase arg
+                   (string
+                    (error-if-not-alphanumeric arg)
+                    (format nil "~s" arg))
                    (cons
                     (cond ((eq (first arg) ':env)
                            (error-if-not-alphanumeric (second arg))
                            (format nil "getenv(\"~a\")" (second arg)))
                           (t
-                           (error "Invalid lisp arg: ~a" arg))))
-                   (string
-                    (error-if-not-alphanumeric arg)
-                    (format nil "~s" arg)))))
+                           (error "Invalid lisp arg: ~a" arg)))))))
 
 (defun write-init-function (name linkage stream &optional (initialize-lisp-args nil))
   (terpri stream)

--- a/src/fasl-lib.lisp
+++ b/src/fasl-lib.lisp
@@ -17,7 +17,9 @@ shared library constructor that loads the embedded FASLs.")
 SBCL runtime.")
 
 (defun create-fasl-library-cmake-project (system-name library directory &key (base-library-name *base-library-name*)
-                                                                          preload-eval-expr)
+                                                                          preload-eval-expr
+                                                                          (omit-init-function t)
+                                                                          (initialize-lisp-args nil))
   "Generate a CMake project in DIRECTORY for a shared library that, when
 loaded into a process that has already initialized the SBCL runtime,
 adds the C symbols for LIBRARY to the current process's symbol table
@@ -44,7 +46,9 @@ be EVALed before loading FASLs."
                           (list target-system)))
          (*base-library-name* base-library-name))
     (compile-bundle-system-with-dependencies target-system build-directory)
-    (build-bindings library build-directory :omit-init-function t)
+    (if omit-init-function
+        (build-bindings library build-directory :omit-init-function t)
+        (build-bindings library build-directory :initialize-lisp-args initialize-lisp-args))
     (create-incbin-source-file build-directory)
     (create-fasl-loader-source-file library systems build-directory :preload-eval-expr preload-eval-expr)
     (create-cmakelists-file library systems build-directory)))


### PR DESCRIPTION
This allows for environment variables as arguments to the sbcl initialization.