### PR TITLE
Environment-configurable heap size

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,4 +69,9 @@ jobs:
         gcc -Wall -o example example.c -lcalc -lsbcl_librarian -lsbcl
         echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" ./example | tr -d '\n' | grep "hello from preload> 3> "
         echo "(+ 1 2)" | LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./example.py | tr -d '\n' | grep "> 3> "
+
+        export SBCL_LIBRARIAN_HEAP_SIZE=7000
+
+        LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./check_dynamic_space_size.py | grep "7340032000"
+        
         LD_LIBRARY_PATH="$LIBSBCL_PATH:$CONDA_PREFIX/lib" python ./exhaust_heap.py | grep "returned to Python after heap exhaustion (attempt 1)"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -72,4 +72,8 @@ jobs:
         gcc -Wall -o example example.c -lcalc -lsbcl_librarian
         echo "(+ 1 2)" | ./example | tr -d '\n' | grep "hello from preload> 3> "
         echo "(+ 1 2)" | python ./example.py | tr -d '\n' | grep "> 3> "
+        export SBCL_LIBRARIAN_HEAP_SIZE=4096
+
+        python ./check_dynamic_space_size.py | grep "4294967296"
+        
         python ./exhaust_heap.py | grep "returned to Python after heap exhaustion (attempt 1)"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,4 +94,9 @@ jobs:
         if ((echo '(+ 1 2)' | .\example.exe) -match "3") { exit 0 } else { exit 1 }
         if ((echo '(+ 1 2)' | .\example.exe) -match "hello from preload") { exit 0 } else { exit 1 }
         if ((echo '(+ 1 2)' | python example.py) -match "3") { exit 0 } else { exit 1 }
+        
+        $env:SBCL_LIBRARIAN_HEAP_SIZE=6144
+
+        if ((python check_dynamic_space_size.py) -match "6442450944") { exit 0 } else { exit 1 }
+
         if ((python exhaust_heap.py) -match "attempt 1") { exit 0 } else { exit 1 }

--- a/README.md
+++ b/README.md
@@ -59,4 +59,6 @@ Process resources SBCL uses:
   so the compiler can generate manifest literal addresses in machine
   code on some platforms, as well as to compute stable hashes of
   certain constants like NIL.
+  
+SBCL heap size (`--dynamic-space-size`) can be set at runtime by using the environment variable `$SBCL_LIBRARIAN_HEAP_SIZE`.
 

--- a/examples/libcalc/bindings.lisp
+++ b/examples/libcalc/bindings.lisp
@@ -9,6 +9,9 @@
     (let ((test '()))
       (loop (push 1 test)))))
 
+(defun print-heap-size ()
+  (format t "~3%~d~3%" (sb-ext:dynamic-space-size)))
+
 (sbcl-librarian:define-api libcalc-api (:function-prefix "calc_")
   (:literal "/* types */")
   (:type expr-type)
@@ -25,7 +28,8 @@
    (parse expr-type ((source :string)))
    (expression-to-string :string ((expr expr-type)))
    (remove-zeros expr-type ((expr expr-type)))
-   (exhaust-heap :void ())))
+   (exhaust-heap :void ())
+   (print-heap-size :void ())))
 
 (sbcl-librarian:define-aggregate-library calc (:function-linkage "CALC_API")
   libcalc-api)

--- a/examples/libcalc/check_dynamic_space_size.py
+++ b/examples/libcalc/check_dynamic_space_size.py
@@ -1,0 +1,16 @@
+import os
+import platform
+
+# Python has trouble finding some dependent DLLs in the Windows CI
+# environment, so we register their directories directly
+if platform.system() == 'Windows':
+    os.add_dll_directory(os.environ.get('LIBSBCL_PATH'))
+    os.add_dll_directory(os.environ.get('MINGW64_PATH'))
+
+import sbcl_librarian.wrapper
+import calc as libcalc
+import sys
+
+if __name__ == '__main__':
+
+    libcalc.calc_print_heap_size()

--- a/lib/entry_point.c
+++ b/lib/entry_point.c
@@ -6,6 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
+#include <stdbool.h>
 
 #include "sbcl_librarian.h"
 
@@ -25,6 +27,8 @@ __thread jmp_buf fatal_lisp_error_handler;
 #endif
 
 #define BUF_SIZE 1024
+
+#define DEFAULT_HEAP_SIZE "8192"
 
 extern char *dir_name(char *path);
 extern void set_lossage_handler(void (*handler)(void));
@@ -48,9 +52,23 @@ static void do_initialize_lisp(const char *libsbcl_librarian_path)
     int core_path_size = libsbcl_librarian_dir_len + sizeof("sbcl_librarian.core") + 1;
     char *core_path = malloc(core_path_size);
 
+    /*
+     * Managing heap size with the environment variable SBCL_LIBRARIAN_HEAP_SIZE
+     */
+
+    char* heap_size;
+
+    char* get_env_heap_size = getenv("SBCL_LIBRARIAN_HEAP_SIZE");
+
+    if (get_env_heap_size == NULL || strlen(get_env_heap_size) == 0) {
+      heap_size = DEFAULT_HEAP_SIZE;
+    } else {
+      heap_size = get_env_heap_size;
+    }
+
     snprintf(core_path, core_path_size, "%ssbcl_librarian.core", libsbcl_librarian_dir);
 
-    const char *init_args[] = {"", "--dynamic-space-size", "8192", "--core", core_path, "--noinform", "--no-userinit"};
+    const char *init_args[] = {"", "--dynamic-space-size", heap_size, "--core", core_path, "--noinform", "--no-userinit"};
 
     /*
      * It seems that on Linux, dlsym(NULL, "sym") fails to find "sym"


### PR DESCRIPTION
This adds an environment variable `$SBCL_LIBRARIAN_HEAP_SIZE` that will change SBCL's dynamic space size at load time.